### PR TITLE
Add callbacks, better put/post notifications

### DIFF
--- a/mbed_cloud_client_resource.cpp
+++ b/mbed_cloud_client_resource.cpp
@@ -57,7 +57,7 @@ void MbedCloudClientResource::methods(unsigned int methodMask) {
     this->methodMask = methodMask;
 }
 
-void MbedCloudClientResource::attach_put_callback(Callback<void(MbedCloudClientResource*, std::string)> callback) {
+void MbedCloudClientResource::attach_put_callback(Callback<void(MbedCloudClientResource*, m2m::String)> callback) {
     this->putCallback = callback;
 }
 
@@ -98,11 +98,11 @@ void MbedCloudClientResource::set_value(const char *value) {
     }
 }
 
-std::string MbedCloudClientResource::get_value() {
+m2m::String MbedCloudClientResource::get_value() {
     if (this->resource) {
-        return std::string(this->resource->get_value_string().c_str());
+        return this->resource->get_value_string();
     } else {
-        return std::string(this->value.c_str());
+        return this->value;
     }
 }
 
@@ -155,7 +155,7 @@ void MbedCloudClientResource::get_data(mcc_resource_def *resourceDef) {
     resourceDef->name = this->name;
     resourceDef->method_mask = this->methodMask;
     resourceDef->observable = this->isObservable;
-    resourceDef->value = m2m::String(this->get_value().c_str());
+    resourceDef->value = this->get_value();
     resourceDef->put_callback = &(this->internalPutCallback);
     resourceDef->post_callback = &(this->internalPostCallback);
     resourceDef->notification_callback = &(this->internalNotificationCallback);

--- a/mbed_cloud_client_resource.cpp
+++ b/mbed_cloud_client_resource.cpp
@@ -146,7 +146,7 @@ const char * MbedCloudClientResource::delivery_status_to_string(const Notication
     }
 }
 
-M2MResource *MbedCloudClientResource::get_resource() {
+M2MResource *MbedCloudClientResource::get_m2m_resource() {
     return resource;
 }
 
@@ -161,6 +161,6 @@ void MbedCloudClientResource::get_data(mcc_resource_def *resourceDef) {
     resourceDef->notification_callback = &(this->internalNotificationCallback);
 }
 
-void MbedCloudClientResource::set_resource(M2MResource *res) {
+void MbedCloudClientResource::set_m2m_resource(M2MResource *res) {
     this->resource = res;
 }

--- a/mbed_cloud_client_resource.cpp
+++ b/mbed_cloud_client_resource.cpp
@@ -36,8 +36,17 @@ void path_to_ids(const char* path, unsigned int *object_id,
 }
 
 MbedCloudClientResource::MbedCloudClientResource(SimpleMbedCloudClient *client, const char *path, const char *name)
-: client(client), resource(NULL), path(path), name(name), putCallback(NULL),
-  postCallback(NULL), notificationCallback(NULL) {
+: client(client),
+  resource(NULL),
+  path(path),
+  name(name),
+  putCallback(NULL),
+  postCallback(NULL),
+  notificationCallback(NULL),
+  internalPostCallback(this, &MbedCloudClientResource::internal_post_callback),
+  internalPutCallback(this, &MbedCloudClientResource::internal_put_callback),
+  internalNotificationCallback(this, &MbedCloudClientResource::internal_notification_callback)
+{
 }
 
 void MbedCloudClientResource::observable(bool observable) {
@@ -48,15 +57,15 @@ void MbedCloudClientResource::methods(unsigned int methodMask) {
     this->methodMask = methodMask;
 }
 
-void MbedCloudClientResource::attach_put_callback(Callback<void(const char*)> callback) {
+void MbedCloudClientResource::attach_put_callback(Callback<void(MbedCloudClientResource*, std::string)> callback) {
     this->putCallback = callback;
 }
 
-void MbedCloudClientResource::attach_post_callback(Callback<void(void*)> callback) {
+void MbedCloudClientResource::attach_post_callback(Callback<void(MbedCloudClientResource*, const uint8_t*, uint16_t)> callback) {
     this->postCallback = callback;
 }
 
-void MbedCloudClientResource::attach_notification_callback(Callback<void(const M2MBase&, const NoticationDeliveryStatus)> callback) {
+void MbedCloudClientResource::attach_notification_callback(Callback<void(MbedCloudClientResource*, const NoticationDeliveryStatus)> callback) {
     this->notificationCallback = callback;
 }
 
@@ -81,7 +90,7 @@ void MbedCloudClientResource::set_value(int value) {
     }
 }
 
-void MbedCloudClientResource::set_value(char *value) {
+void MbedCloudClientResource::set_value(const char *value) {
     this->value = value;
 
     if (this->resource) {
@@ -89,12 +98,56 @@ void MbedCloudClientResource::set_value(char *value) {
     }
 }
 
-String MbedCloudClientResource::get_value() {
+std::string MbedCloudClientResource::get_value() {
     if (this->resource) {
-        return this->resource->get_value_string();
+        return std::string(this->resource->get_value_string().c_str());
     } else {
-        return this->value;
+        return std::string(this->value.c_str());
     }
+}
+
+void MbedCloudClientResource::internal_post_callback(void *params) {
+    if (!postCallback) return;
+
+    if (params) { // data can be NULL!
+        M2MResource::M2MExecuteParameter* parameters = static_cast<M2MResource::M2MExecuteParameter*>(params);
+
+        // extract the data that was sent
+        const uint8_t* buffer = parameters->get_argument_value();
+        uint16_t length = parameters->get_argument_value_length();
+
+        postCallback(this, buffer, length);
+    }
+}
+
+void MbedCloudClientResource::internal_put_callback(const char* resource) {
+    if (!putCallback) return;
+
+    putCallback(this, this->get_value());
+}
+
+void MbedCloudClientResource::internal_notification_callback(const M2MBase& m2mbase, const NoticationDeliveryStatus status) {
+    if (!notificationCallback) return;
+
+    notificationCallback(this, status);
+}
+
+const char * MbedCloudClientResource::delivery_status_to_string(const NoticationDeliveryStatus status) {
+    switch(status) {
+        case NOTIFICATION_STATUS_INIT: return "Init";
+        case NOTIFICATION_STATUS_BUILD_ERROR: return "Build error";
+        case NOTIFICATION_STATUS_RESEND_QUEUE_FULL: return "Resend queue full";
+        case NOTIFICATION_STATUS_SENT: return "Sent";
+        case NOTIFICATION_STATUS_DELIVERED: return "Delivered";
+        case NOTIFICATION_STATUS_SEND_FAILED: return "Send failed";
+        case NOTIFICATION_STATUS_SUBSCRIBED: return "Subscribed";
+        case NOTIFICATION_STATUS_UNSUBSCRIBED: return "Unsubscribed";
+        default: return "Unknown";
+    }
+}
+
+M2MResource *MbedCloudClientResource::get_resource() {
+    return resource;
 }
 
 void MbedCloudClientResource::get_data(mcc_resource_def *resourceDef) {
@@ -102,10 +155,10 @@ void MbedCloudClientResource::get_data(mcc_resource_def *resourceDef) {
     resourceDef->name = this->name;
     resourceDef->method_mask = this->methodMask;
     resourceDef->observable = this->isObservable;
-    resourceDef->value = this->get_value();
-    resourceDef->put_callback = &(this->putCallback);
-    resourceDef->post_callback = &(this->postCallback);
-    resourceDef->notification_callback = &(this->notificationCallback);
+    resourceDef->value = m2m::String(this->get_value().c_str());
+    resourceDef->put_callback = &(this->internalPutCallback);
+    resourceDef->post_callback = &(this->internalPostCallback);
+    resourceDef->notification_callback = &(this->internalNotificationCallback);
 }
 
 void MbedCloudClientResource::set_resource(M2MResource *res) {

--- a/mbed_cloud_client_resource.h
+++ b/mbed_cloud_client_resource.h
@@ -48,8 +48,8 @@ class MbedCloudClientResource {
         std::string get_value();
 
         void get_data(mcc_resource_def *resourceDef);
-        void set_resource(M2MResource *res);
-        M2MResource* get_resource();
+        void set_m2m_resource(M2MResource *res);
+        M2MResource* get_m2m_resource();
 
         static const char * delivery_status_to_string(const NoticationDeliveryStatus status);
 

--- a/mbed_cloud_client_resource.h
+++ b/mbed_cloud_client_resource.h
@@ -37,7 +37,7 @@ class MbedCloudClientResource {
 
         void observable(bool observable);
         void methods(unsigned int methodMask);
-        void attach_put_callback(Callback<void(MbedCloudClientResource*, std::string)> callback);
+        void attach_put_callback(Callback<void(MbedCloudClientResource*, m2m::String)> callback);
         void attach_post_callback(Callback<void(MbedCloudClientResource*, const uint8_t*, uint16_t)> callback);
         void attach_notification_callback(Callback<void(MbedCloudClientResource*, const NoticationDeliveryStatus)> callback);
         void detach_put_callback();
@@ -45,7 +45,7 @@ class MbedCloudClientResource {
         void detach_notification_callback();
         void set_value(int value);
         void set_value(const char *value);
-        std::string get_value();
+        m2m::String get_value();
 
         void get_data(mcc_resource_def *resourceDef);
         void set_m2m_resource(M2MResource *res);
@@ -60,13 +60,13 @@ class MbedCloudClientResource {
 
         SimpleMbedCloudClient *client;
         M2MResource *resource;
-        String path;
-        String name;
-        String value;
+        m2m::String path;
+        m2m::String name;
+        m2m::String value;
         bool isObservable;
         unsigned int methodMask;
 
-        Callback<void(MbedCloudClientResource*, std::string)> putCallback;
+        Callback<void(MbedCloudClientResource*, m2m::String)> putCallback;
         Callback<void(MbedCloudClientResource*, const uint8_t*, uint16_t)> postCallback;
         Callback<void(MbedCloudClientResource*, const NoticationDeliveryStatus)> notificationCallback;
         Callback<void(void*)> internalPostCallback;

--- a/mbed_cloud_client_resource.h
+++ b/mbed_cloud_client_resource.h
@@ -37,20 +37,27 @@ class MbedCloudClientResource {
 
         void observable(bool observable);
         void methods(unsigned int methodMask);
-        void attach_put_callback(Callback<void(const char*)> callback);
-        void attach_post_callback(Callback<void(void*)> callback);
-        void attach_notification_callback(Callback<void(const M2MBase&, const NoticationDeliveryStatus)> callback);
+        void attach_put_callback(Callback<void(MbedCloudClientResource*, std::string)> callback);
+        void attach_post_callback(Callback<void(MbedCloudClientResource*, const uint8_t*, uint16_t)> callback);
+        void attach_notification_callback(Callback<void(MbedCloudClientResource*, const NoticationDeliveryStatus)> callback);
         void detach_put_callback();
         void detach_post_callback();
         void detach_notification_callback();
         void set_value(int value);
-        void set_value(char *value);
-        String get_value();
+        void set_value(const char *value);
+        std::string get_value();
 
         void get_data(mcc_resource_def *resourceDef);
         void set_resource(M2MResource *res);
+        M2MResource* get_resource();
+
+        static const char * delivery_status_to_string(const NoticationDeliveryStatus status);
 
     private:
+        void internal_post_callback(void* params);
+        void internal_put_callback(const char* resource);
+        void internal_notification_callback(const M2MBase& m2mbase, const NoticationDeliveryStatus status);
+
         SimpleMbedCloudClient *client;
         M2MResource *resource;
         String path;
@@ -59,9 +66,12 @@ class MbedCloudClientResource {
         bool isObservable;
         unsigned int methodMask;
 
-        Callback<void(const char*)> putCallback;
-        Callback<void(void*)> postCallback;
-        Callback<void(const M2MBase&, const NoticationDeliveryStatus)> notificationCallback;
+        Callback<void(MbedCloudClientResource*, std::string)> putCallback;
+        Callback<void(MbedCloudClientResource*, const uint8_t*, uint16_t)> postCallback;
+        Callback<void(MbedCloudClientResource*, const NoticationDeliveryStatus)> notificationCallback;
+        Callback<void(void*)> internalPostCallback;
+        Callback<void(const char*)> internalPutCallback;
+        Callback<void(const M2MBase&, const NoticationDeliveryStatus)> internalNotificationCallback;
 };
 
 #endif // MBED_CLOUD_CLIENT_RESOURCE_H

--- a/memory_tests.cpp
+++ b/memory_tests.cpp
@@ -1,0 +1,223 @@
+// ----------------------------------------------------------------------------
+// Copyright 2016-2017 ARM Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------
+
+
+#ifdef TARGET_LIKE_MBED
+
+#ifdef MBED_HEAP_STATS_ENABLED
+// used by print_heap_stats only
+#include "mbed_stats.h"
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include "mbed-client/m2mbase.h"
+#endif
+
+// fixup the compilation on AMRCC for PRIu32
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+#include "memory_tests.h"
+
+#include "mbed-client/m2mblockmessage.h"
+#include "mbed-client/m2mdevice.h"
+#include "mbed-client/m2mfirmware.h"
+#include "mbed-client/m2minterfacefactory.h"
+#include "mbed-client/m2mobject.h"
+#include "mbed-client/m2mserver.h"
+#include "mbed-client/m2msecurity.h"
+#include "source/include/m2mreporthandler.h"
+
+#include "mbed.h"
+#include "mbed_stats.h"
+
+#include <assert.h>
+
+void heap_stats()
+{
+#ifdef MBED_HEAP_STATS_ENABLED
+    mbed_stats_heap_t stats;
+    mbed_stats_heap_get(&stats);
+    printf("**** current_size: %" PRIu32 "\n", stats.current_size);
+    printf("**** max_size    : %" PRIu32 "\n", stats.max_size);
+#endif // MBED_HEAP_STATS_ENABLED
+}
+
+void m2mobject_test_set(M2MObjectList& object_list)
+{
+#ifdef MBED_HEAP_STATS_ENABLED
+    printf("*************************************\n");
+
+    mbed_stats_heap_t stats;
+    mbed_stats_heap_get(&stats);
+
+    uint32_t initial = stats.current_size;
+
+    const int object_count = 1;
+    const int object_id_range_start = 90;
+    const int object_id_range_end = object_id_range_start + object_count;
+
+    const int object_instance_count = 5;
+    const int resource_count = 5;
+
+    int total_object_count = 0;
+    int total_object_instance_count = 0;
+    int total_resource_count = 0;
+
+    for (int object_id = object_id_range_start; object_id < object_id_range_end; object_id++) {
+
+        char buff[64];
+        sprintf(buff, "%d", object_id);
+        M2MObject *obj = M2MInterfaceFactory::create_object(buff);
+
+        for (int object_instance_id = 0; object_instance_id < object_instance_count; object_instance_id++) {
+
+            M2MObjectInstance* obj_inst = obj->create_object_instance(object_instance_id);
+
+            assert(obj_inst != NULL);
+            total_object_instance_count++;
+            for (int resource_id = 0; resource_id < resource_count; resource_id++) {
+                String res_name;
+                String res_type;
+
+                res_name.append_int(resource_id);
+                res_type.append_int(resource_id);
+
+                M2MResource* resource = obj_inst->create_dynamic_resource(res_name, res_type,
+                                                                        M2MResourceInstance::INTEGER, true);
+
+                assert(resource != NULL);
+
+                resource->set_operation(M2MBase::GET_ALLOWED);
+                resource->set_value(7);
+
+                total_resource_count++;
+            }
+        }
+
+        object_list.push_back(obj);
+        total_object_count++;
+    }
+
+    printf("objects       : %d\n", total_object_count);
+    printf("obj instances : %d\n", total_object_instance_count);
+    printf("resources     : %d\n", total_resource_count);
+
+    mbed_stats_heap_get(&stats);
+    printf("heap used     : %" PRIu32 "\n", stats.current_size - initial);
+
+    printf("*************************************\n");
+#endif // MBED_HEAP_STATS_ENABLED
+}
+
+// Note: the mbed-os needs to be compiled with MBED_HEAP_STATS_ENABLED to get
+// functional heap stats, or the mbed_stats_heap_get() will return just zeroes.
+void m2mobject_stats()
+{
+#ifdef MBED_HEAP_STATS_ENABLED
+    printf("\n*** M2M object sizes in bytes ***\n");
+    printf("M2MBase: %" PRIu32 "\n", sizeof(M2MBase));
+    printf("M2MObject: %" PRIu32 "\n", sizeof(M2MObject));
+    printf("M2MObjectInstance: %" PRIu32 "\n", sizeof(M2MObjectInstance));
+    printf("M2MResource: %" PRIu32 "\n", sizeof(M2MResource));
+    printf("M2MResourceInstance: %" PRIu32 "\n", sizeof(M2MResourceInstance));
+    printf("M2MDevice: %" PRIu32 "\n", sizeof(M2MDevice));
+    printf("M2MFirmware: %" PRIu32 "\n", sizeof(M2MFirmware));
+    printf("M2MServer: %" PRIu32 "\n", sizeof(M2MServer));
+    printf("M2MSecurity: %" PRIu32 "\n", sizeof(M2MSecurity));
+    printf("M2MBlockMessage: %" PRIu32 "\n", sizeof(M2MBlockMessage));
+    printf("M2MReportHandler: %" PRIu32 "\n", sizeof(M2MReportHandler));
+    printf("*************************************\n\n");
+
+    mbed_stats_heap_t stats;
+    mbed_stats_heap_get(&stats);
+
+    printf("*** M2M heap stats in bytes***\n");
+    uint32_t initial = stats.current_size;
+
+    // M2MDevice
+    M2MDevice *device_object = M2MInterfaceFactory::create_device();
+    assert(device_object);
+    mbed_stats_heap_get(&stats);
+    printf("M2MDevice heap size: %" PRIu32 "\n", stats.current_size - initial);
+    M2MDevice::delete_instance();
+    mbed_stats_heap_get(&stats);
+    if (initial != stats.current_size) {
+        printf("M2MDevice leaked: %" PRIu32 "bytes\n", stats.current_size - initial);
+    }
+
+    // M2MServer
+    initial = stats.current_size;
+    M2MServer *server = M2MInterfaceFactory::create_server();
+    mbed_stats_heap_get(&stats);
+    printf("M2MServer heap size: %" PRIu32 "\n", stats.current_size - initial);
+    delete server;
+    mbed_stats_heap_get(&stats);
+    if (initial != stats.current_size) {
+        printf("M2MServer leaked: %" PRIu32 "bytes\n", stats.current_size - initial);
+    }
+
+    // M2MSecurity
+    initial = stats.current_size;
+    M2MSecurity *security = M2MInterfaceFactory::create_security(M2MSecurity::M2MServer);
+    mbed_stats_heap_get(&stats);
+    printf("M2MSecurity heap size: %" PRIu32 "\n", stats.current_size - initial);
+    M2MSecurity::delete_instance();
+    mbed_stats_heap_get(&stats);
+    if (initial != stats.current_size) {
+        printf("M2MSecurity leaked: %" PRIu32 "bytes\n", stats.current_size - initial);
+    }
+
+    // M2MFirmware
+    initial = stats.current_size;
+    M2MFirmware *firmware = M2MInterfaceFactory::create_firmware();
+    assert(firmware);
+    mbed_stats_heap_get(&stats);
+    printf("M2MFirmware heap size: %" PRIu32 "\n", stats.current_size - initial);
+    M2MFirmware::delete_instance();
+    mbed_stats_heap_get(&stats);
+    if (initial != stats.current_size) {
+        printf("M2MFirmware leaked: %" PRIu32 "bytes\n", stats.current_size - initial);
+    }
+
+    // Basic object creation
+    initial = stats.current_size;
+    uint32_t before_object = initial;
+    M2MObject *obj = M2MInterfaceFactory::create_object("1");
+    mbed_stats_heap_get(&stats);
+    printf("M2MObject heap size: %" PRIu32 "\n", stats.current_size - initial);
+    initial = stats.current_size;
+
+    M2MObjectInstance* obj_inst = obj->create_object_instance();
+    mbed_stats_heap_get(&stats);
+    printf("M2MObjectInstance heap size: %" PRIu32 "\n", stats.current_size - initial);
+
+    initial = stats.current_size;
+    M2MResource* res = obj_inst->create_dynamic_resource("1", "1", M2MResourceInstance::STRING, false);
+    assert(res);
+    mbed_stats_heap_get(&stats);
+    printf("M2MResource heap size: %" PRIu32 "\n", stats.current_size - initial);
+
+    delete obj;
+    mbed_stats_heap_get(&stats);
+    if (before_object != stats.current_size) {
+        printf("Resource leaked: %" PRIu32 "bytes\n", stats.current_size - before_object);
+    }
+    printf("*************************************\n\n");
+#endif // MBED_HEAP_STATS_ENABLED
+}
+#endif // TARGET_LIKE_MBED

--- a/resource.cpp
+++ b/resource.cpp
@@ -68,7 +68,7 @@ M2MResource* add_resource(M2MObjectList *list, uint16_t object_id, uint16_t inst
     snprintf(name, 6, "%d", resource_id);
     resource = object_instance->create_dynamic_resource(name, resource_type, data_type, observable);
     //Set value if available.
-    if (value != "") {
+    if (strcmp(value, "") != 0) {
         resource->set_value((const unsigned char*)value, strlen(value));
     }
     //Set allowed operations for accessing the resource.
@@ -77,14 +77,18 @@ M2MResource* add_resource(M2MObjectList *list, uint16_t object_id, uint16_t inst
         resource->set_notification_delivery_status_cb(notification_delivery_status_cb_thunk, notification_status_cb);
     }
 
+    if (put_cb) {
+        resource->set_value_updated_function(
+            FP1<void, const char*>(put_cb,
+                (void (Callback<void(const char*)>::*)(const char*))
+                    &Callback<void(const char*)>::call));
+    }
 
-    resource->set_value_updated_function(
-        FP1<void, const char*>(put_cb,
-            (void (Callback<void(const char*)>::*)(const char*))
-                &Callback<void(const char*)>::call));
-    resource->set_execute_function(FP1<void, void*>(post_cb,
-        (void (Callback<void(void*)>::*)(void*))
-            &Callback<void(void*)>::call));
+    if (post_cb) {
+        resource->set_execute_function(FP1<void, void*>(post_cb,
+            (void (Callback<void(void*)>::*)(void*))
+                &Callback<void(void*)>::call));
+    }
 
     return resource;
 }

--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -41,7 +41,9 @@
 #include "memory_tests.h"
 #endif
 
+#ifndef DEFAULT_FIRMWARE_PATH
 #define DEFAULT_FIRMWARE_PATH       "/sd/firmware"
+#endif
 
 SimpleMbedCloudClient::SimpleMbedCloudClient(NetworkInterface *net) :
     _registered(false),

--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -70,7 +70,7 @@ int SimpleMbedCloudClient::init() {
     // Initialize the FCC
     fcc_status_e fcc_status = fcc_init();
     if(fcc_status != FCC_STATUS_SUCCESS) {
-        printf("fcc_init failed with status %d! - exit\n", fcc_status);
+        printf("[Simple Cloud Client] Factory Client Configuration failed with status %d. \n", fcc_status);
         return 1;
     }
 
@@ -78,10 +78,10 @@ int SimpleMbedCloudClient::init() {
     // Use this function when you want to clear storage from all the factory-tool generated data and user data.
     // After this operation device must be injected again by using factory tool or developer certificate.
 #ifdef RESET_STORAGE
-    printf("Reset storage to an empty state.\n");
+    printf("[Simple Cloud Client] Reset storage to an empty state.\n");
     fcc_status_e delete_status = fcc_storage_delete();
     if (delete_status != FCC_STATUS_SUCCESS) {
-        printf("Failed to delete storage - %d\n", delete_status);
+        printf("[Simple Cloud Client] Failed to delete storage - %d\n", delete_status);
     }
 #endif
 
@@ -92,28 +92,28 @@ int SimpleMbedCloudClient::init() {
     palStatus_t status = PAL_SUCCESS;
     status = pal_fsRmFiles(DEFAULT_FIRMWARE_PATH);
     if(status == PAL_SUCCESS) {
-        printf("Firmware storage erased.\n");
+        printf("[Simple Cloud Client] Firmware storage erased.\n");
     } else if (status == PAL_ERR_FS_NO_PATH) {
-        printf("Firmware path not found/does not exist.\n");
+        printf("[Simple Cloud Client] Firmware path not found/does not exist.\n");
     } else {
-        printf("Firmware storage erasing failed with %" PRId32, status);
+        printf("[Simple Cloud Client] Firmware storage erasing failed with %" PRId32, status);
         return 1;
     }
 #endif
 
 #if MBED_CONF_APP_DEVELOPER_MODE == 1
-    printf("Start developer flow\n");
+    printf("[Simple Cloud Client] Starting developer flow\n");
     fcc_status = fcc_developer_flow();
     if (fcc_status == FCC_STATUS_KCM_FILE_EXIST_ERROR) {
-        printf("Developer credentials already exist\n");
+        printf("[Simple Cloud Client] Developer credentials already exist\n");
     } else if (fcc_status != FCC_STATUS_SUCCESS) {
-        printf("Failed to load developer credentials - exit\n");
+        printf("[Simple Cloud Client] Failed to load developer credentials - is the storage device active and accessible?\n");
         return 1;
     }
 #endif
     fcc_status = fcc_verify_device_configured_4mbed_cloud();
     if (fcc_status != FCC_STATUS_SUCCESS) {
-        printf("Device not configured for mbed Cloud - exit\n");
+        printf("[Simple Cloud Client] Device not configured for mbed Cloud - try re-formatting your storage device\n");
         return 1;
     }
 
@@ -126,11 +126,10 @@ bool SimpleMbedCloudClient::call_register() {
     _cloud_client.on_unregistered(this, &SimpleMbedCloudClient::client_unregistered);
     _cloud_client.on_error(this, &SimpleMbedCloudClient::error);
 
-    printf("Connecting...\n");
     bool setup = _cloud_client.setup(_net);
     _register_called = true;
     if (!setup) {
-        printf("Client setup failed\n");
+        printf("[Simple Cloud Client] Client setup failed\n");
         return false;
     }
 
@@ -265,9 +264,11 @@ void SimpleMbedCloudClient::error(int error_code) {
         default:
             error = "UNKNOWN";
     }
-    printf("\nError occurred : %s\r\n", error);
-    printf("Error code : %d\r\n\n", error_code);
-    printf("Error details : %s\r\n\n",_cloud_client.error_description());
+
+    // @todo: move this into user space
+    printf("\n[Simple Cloud Client] Error occurred : %s\n", error);
+    printf("[Simple Cloud Client] Error code : %d\n", error_code);
+    printf("[Simple Cloud Client] Error details : %s\n",_cloud_client.error_description());
 }
 
 bool SimpleMbedCloudClient::is_client_registered() {
@@ -298,7 +299,7 @@ void SimpleMbedCloudClient::register_and_connect() {
 
     // Print memory statistics if the MBED_HEAP_STATS_ENABLED is defined.
     #ifdef MBED_HEAP_STATS_ENABLED
-        printf("Register being called\r\n");
+        printf("[Simple Cloud Client] Register being called\r\n");
         heap_stats();
     #endif
 }

--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -46,8 +46,8 @@
 SimpleMbedCloudClient::SimpleMbedCloudClient(NetworkInterface *net) :
     _registered(false),
     _register_called(false),
-    _registered_cb(0),
-    _unregistered_cb(0),
+    _registered_cb(NULL),
+    _unregistered_cb(NULL),
     _net(net)
 {
 }
@@ -290,7 +290,7 @@ void SimpleMbedCloudClient::register_and_connect() {
                      resourceDef.resource_id, resourceDef.name.c_str(), M2MResourceInstance::STRING,
                      (M2MBase::Operation)resourceDef.method_mask, resourceDef.value.c_str(), resourceDef.observable,
                      resourceDef.put_callback, resourceDef.post_callback, resourceDef.notification_callback);
-        _resources[i]->set_resource(res);
+        _resources[i]->set_m2m_resource(res);
     }
     _cloud_client.add_objects(_obj_list);
 

--- a/simple-mbed-cloud-client.h
+++ b/simple-mbed-cloud-client.h
@@ -50,14 +50,18 @@ public:
     void register_and_connect();
     MbedCloudClient& get_cloud_client();
     MbedCloudClientResource* create_resource(const char *path, const char *name);
+    void on_registered(Callback<void(const ConnectorClientEndpointInfo*)> cb);
+    void on_unregistered(Callback<void()> cb);
 
 private:
-    M2MObjectList       _obj_list;
-    MbedCloudClient     _cloud_client;
-    bool                _registered;
-    bool                _register_called;
-    Vector<MbedCloudClientResource*> _resources;
-    NetworkInterface *net;
+    M2MObjectList                                       _obj_list;
+    MbedCloudClient                                     _cloud_client;
+    bool                                                _registered;
+    bool                                                _register_called;
+    Vector<MbedCloudClientResource*>                    _resources;
+    Callback<void(const ConnectorClientEndpointInfo*)>  _registered_cb;
+    Callback<void()>                                    _unregistered_cb;
+    NetworkInterface *                                  _net;
 };
 
 #endif // SIMPLEMBEDCLOUDCLIENT_H


### PR DESCRIPTION
Merging a bunch of work that I did for the original Simple Cloud Client into this project:

* Add on_registered / on_unregistered callbacks and remove unnecessary printf() statements from client.
* Create better put/post/notification callbacks, which actually give some useful information rather than leaking internal structures into the user application.
    * PUT handlers now get the new value of the resource.
    * POST handlers now receive the decoded body of the POST request.
    * Notification handlers can get a string version of the notification.
    * All callbacks also receive the resource as parameter, so you don't need to clobber global scope.

I've updated the example app [here](https://gist.github.com/janjongboom/9923191ab107acddfd79e10c05ca4d1f) - as I could not find it on GitHub.

Note that I still believe this API is not clean enough. Example app remains 170 lines of code. Also I miss typing information, now we let users cast stuff all the time.

@bridadan @MarceloSalazar 