### PR TITLE
Mount filesystem if wasn't done in the application

### DIFF
--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -92,7 +92,9 @@ int SimpleMbedCloudClient::init() {
         int mount_result = mount_storage();
         if (mount_result != 0) {
             printf("[Simple Cloud Client] Failed to mount file system with status %d. \n", mount_result);
+#if !defined(MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR) || MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR == 0
             return 1;
+#endif
         } else {
             // Retry with mounted filesystem.
             fcc_status = fcc_verify_device_configured_4mbed_cloud();

--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -86,6 +86,9 @@ int SimpleMbedCloudClient::init() {
         return 1;
     }
 
+    //Initialise the storage
+    int mount_result = mount_storage();
+
     // This is designed to simplify user-experience by auto-formatting the
     // primary storage if no valid certificates exist.
     // This should never be used for any kind of production devices.
@@ -371,4 +374,14 @@ void SimpleMbedCloudClient::reset_storage()
     if (delete_status != FCC_STATUS_SUCCESS) {
         printf("[Simple Cloud Client] Failed to delete storage - %d\n", delete_status);
     }
+}
+
+int SimpleMbedCloudClient::mount_storage()
+{
+	int mount_result = -1;
+	printf("[Simple Cloud Client] Initialising storage.\n");
+	if (_bd) {
+		mount_result = _fs->mount(_bd);
+	}
+	return mount_result;
 }

--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -88,6 +88,10 @@ int SimpleMbedCloudClient::init() {
 
     //Initialise the storage
     int mount_result = mount_storage();
+	if (mount_result != 0) {
+		printf("[Simple Cloud Client] Failed to mount file system with status %d. \n", mount_result);
+		return 1;
+	}
 
     // This is designed to simplify user-experience by auto-formatting the
     // primary storage if no valid certificates exist.

--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -86,10 +86,6 @@ int SimpleMbedCloudClient::init() {
         return 1;
     }
 
-    // This is designed to simplify user-experience by auto-formatting the
-    // primary storage if no valid certificates exist.
-    // This should never be used for any kind of production devices.
-#if defined(MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR) && MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR == 1
     fcc_status = fcc_verify_device_configured_4mbed_cloud();
 
     if (fcc_status == FCC_STATUS_KCM_STORAGE_ERROR) {
@@ -102,6 +98,11 @@ int SimpleMbedCloudClient::init() {
             fcc_status = fcc_verify_device_configured_4mbed_cloud();
         }
     }
+
+    // This is designed to simplify user-experience by auto-formatting the
+    // primary storage if no valid certificates exist.
+    // This should never be used for any kind of production devices.
+#if defined(MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR) && MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR == 1
     if (fcc_status != FCC_STATUS_SUCCESS) {
         if (reformat_storage() != 0) {
             return 1;
@@ -110,18 +111,6 @@ int SimpleMbedCloudClient::init() {
         reset_storage();
     }
 #else
-    fcc_status = fcc_verify_device_configured_4mbed_cloud();
-
-    if (fcc_status == FCC_STATUS_KCM_STORAGE_ERROR) {
-        int mount_result = mount_storage();
-        if (mount_result != 0) {
-            printf("[Simple Cloud Client] Failed to mount file system with status %d. \n", mount_result);
-            return 1;
-        } else {
-            // Retry with mounted filesystem.
-            fcc_status = fcc_verify_device_configured_4mbed_cloud();
-        }
-    }
     if (fcc_status != FCC_STATUS_SUCCESS) {
         printf("[Simple Cloud Client] Device not configured for mbed Cloud - try re-formatting your storage device or set MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR to 1\n");
         return 1;

--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -86,18 +86,22 @@ int SimpleMbedCloudClient::init() {
         return 1;
     }
 
-    //Initialise the storage
-    int mount_result = mount_storage();
-	if (mount_result != 0) {
-		printf("[Simple Cloud Client] Failed to mount file system with status %d. \n", mount_result);
-		return 1;
-	}
-
     // This is designed to simplify user-experience by auto-formatting the
     // primary storage if no valid certificates exist.
     // This should never be used for any kind of production devices.
 #if defined(MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR) && MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR == 1
     fcc_status = fcc_verify_device_configured_4mbed_cloud();
+
+    if (fcc_status == FCC_STATUS_KCM_STORAGE_ERROR) {
+        int mount_result = mount_storage();
+        if (mount_result != 0) {
+            printf("[Simple Cloud Client] Failed to mount file system with status %d. \n", mount_result);
+            return 1;
+        } else {
+            // Retry with mounted filesystem.
+            fcc_status = fcc_verify_device_configured_4mbed_cloud();
+        }
+    }
     if (fcc_status != FCC_STATUS_SUCCESS) {
         if (reformat_storage() != 0) {
             return 1;
@@ -107,6 +111,17 @@ int SimpleMbedCloudClient::init() {
     }
 #else
     fcc_status = fcc_verify_device_configured_4mbed_cloud();
+
+    if (fcc_status == FCC_STATUS_KCM_STORAGE_ERROR) {
+        int mount_result = mount_storage();
+        if (mount_result != 0) {
+            printf("[Simple Cloud Client] Failed to mount file system with status %d. \n", mount_result);
+            return 1;
+        } else {
+            // Retry with mounted filesystem.
+            fcc_status = fcc_verify_device_configured_4mbed_cloud();
+        }
+    }
     if (fcc_status != FCC_STATUS_SUCCESS) {
         printf("[Simple Cloud Client] Device not configured for mbed Cloud - try re-formatting your storage device or set MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR to 1\n");
         return 1;
@@ -382,10 +397,10 @@ void SimpleMbedCloudClient::reset_storage()
 
 int SimpleMbedCloudClient::mount_storage()
 {
-	int mount_result = -1;
-	printf("[Simple Cloud Client] Initialising storage.\n");
-	if (_bd) {
-		mount_result = _fs->mount(_bd);
-	}
-	return mount_result;
+    int mount_result = -1;
+    printf("[Simple Cloud Client] Initializing storage.\n");
+    if (_bd) {
+        mount_result = _fs->mount(_bd);
+    }
+    return mount_result;
 }

--- a/simple-mbed-cloud-client.h
+++ b/simple-mbed-cloud-client.h
@@ -55,6 +55,7 @@ public:
 private:
     int reformat_storage();
     void reset_storage();
+    int mount_storage();
 
     M2MObjectList                                       _obj_list;
     MbedCloudClient                                     _cloud_client;


### PR DESCRIPTION
Added an explicit call to fs->mount() in the init() function.

FileSystem does not require a block device to be passed to it:
https://github.com/ARMmbed/mbed-os-example-filesystem/blob/master/main.cpp#L39

If you do not pass a block device to the constructor, it will not automatically do a mount. By calling mount() explicitly, we support constructors without this block device.

Tested with LittleFileSystem and FATFileSystem.

Without this fix, if you do not pass a block device to your file system constructor, the FCC looks for an unmounted file system, thus your credentials will be written over and you will receive a new device identity. 
