### PR TITLE
Simple Cloud Client Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud 
 },
 "test-socket-object": {
     "help": "Instantiation of network interface statement for SMCC tests. (variable name must be net)",
-    "value": "EthernetInterface net"
+    "value": "EthernetInterface net;"
 },
 "test-socket-connect": {
     "help": "Network socket connect statement for SMCC tests.",

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ If you receive a stack overflow error, increase the Mbed OS main stack size to a
  "MBED_CONF_APP_MAIN_STACK_SIZE=6000",
 ```
 
+#### Device failed to register
+Check the device allocation on your Mbed Cloud account to see if you are allowed additional devices to connect. You can delete development devices, after being deleted they will not count towards your allocation.
+
 
 ### Known issues
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,35 @@ For more examples and a template `mbed_app.json`, see [simple-mbed-cloud-client-
 
 5. Run the Simple Mbed Cloud Client tests from the application directory: 
  ` mbed test -m <platform> -t <toolchain> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*`
+ 
+### Troubleshooting
+Below are a list of common issues and fixes for using Simple Mbed Cloud Client.
+
+#### Autoformatting failed with error -5005
+This is due to an issue with the storage block device. If using an SD card, ensure that the SD card is seated properly.
+
+#### SYNC_FAILED during testing
+Occasionally, if the test failed during a previous attempt, the SMCC Greentea tests will fail to sync. If this is the case, please replug your device to the host PC. Additionally, you may need to update your DAPLink or ST-Link interface firmware.
+
+#### Device identity is inconsistent
+If your device ID in Mbed Cloud is inconsistent over a device reset, it could be because it is failing to open the credentials on the storage held in the Enhanced Secure File System. Typically, this is because the device cannot access the Root of Trust stored in SOTP.
+
+One way to verify this is to see if Simple Mbed Cloud Client autoformats the storage after a device reset when `format-storage-layer-on-error` is set to `1` in `mbed_app.json`.  It would appear on the serial terminal output from the device as the following:
+```
+[Simple Cloud Client] Initializing storage.
+[Simple Cloud Client] Autoformatting the storage.
+[Simple Cloud Client] Reset storage to an empty state.
+[Simple Cloud Client] Starting developer flow
+```
+
+When this occurs, you should look at the SOTP sectors defined in `mbed_app.json`:
+```
+"sotp-section-1-address"           : "0xFE000",
+"sotp-section-1-size"              : "0x1000",
+"sotp-section-2-address"           : "0xFF000",
+"sotp-section-2-size"              : "0x1000",
+```
+Ensure that the sectors are correct according to the flash layout of your device, and they are not being overwritten during the programming of the device. ST-Link devices will overwrite these sectors when using drag-and-drop of .bin files. Thus, moving the SOTP sectors to the end sectors of flash ensure that they will not be overwritten.
 
 ### Known issues
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Simple Mbed Cloud Client
+# Simple Mbed Cloud Client
 
 A simple way of connecting Mbed OS 5 devices to Mbed Cloud. It's designed to:
 
@@ -10,7 +10,7 @@ A simple way of connecting Mbed OS 5 devices to Mbed Cloud. It's designed to:
 
 This library is a simpler interface to Mbed Cloud Client, making it trivial to expose sensors, actuators and other variables to the cloud. For a full Mbed Cloud CLient API, check our [documentation](https://cloud.mbed.com/docs/current/mbed-cloud-client/index.html).
 
-### Usage to Connect to Mbed Cloud
+## Usage to Connect to Mbed Cloud
 
 1. Add this library to your Mbed OS project:
 
@@ -51,21 +51,79 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
     }
     ```
    
-### Example applications
+## Example applications
   
   There are a number of applications that make usage of the Simple Mbed Cloud Client library.
   
   The Mbed Cloud [Quick-Start](https://cloud.mbed.com/quick-start) is an initiative to support Mbed Partner's platforms while delivering a great User Experience to Mbed Developers.  
 
-### Testing
+## Testing
 
-Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud Client porting efforts. For detailed instructions on how to run the Simple Mbed Cloud Client Tests, see [simple-mbed-cloud-client-template-restricted](https://github.com/armmbed/simple-mbed-cloud-client-template-restricted).
+Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud Client porting efforts. 
+
+### Tests
 
 | **Test Name** | **Description** |
 | ------------- | ------------- |
 | `simple-connect` | Tests that the device successfully registers to Mbed Cloud using the specified storage, SOTP, and connectivity configuration. Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID.  |
 
+### Requirements
+ Simple Mbed Cloud Client tests rely on the Python SDK to test the end to end solution. 
+ To install the Python SDK:
+`pip install mbed-cloud-sdk`
+ **Note:** The Python SDK requires Python 2.7.10+ / Python 3.4.3+, built with SSL support.
+ 
+ ### Setup
+ 
+ 1. Include the `mbed_cloud_dev_credentials.c` developer certificate in your application. For detailed instructions [see the documentation](https://cloud.mbed.com/docs/current/connecting/provisioning-development-devices.html#creating-and-downloading-a-developer-certificate).
+ 
+ 2. Set an environment variable on the host machine called `MBED_CLOUD_API_KEY` which is valid for the account that your device will connect to. For instructions on how to generate an API key, please [see the documentation](https://cloud.mbed.com/docs/current/integrate-web-app/api-keys.html#generating-an-api-key).
+ 
+ 3. In your reference application, change the following parameters in `mbed_app.json` to the parameters specific to your platform:
+ ```json      
+"test-connect-header-file": {
+    "help": "Name of socket interface for SMCC tests.",
+    "value": "\"EthernetInterface.h\""
+},
+"test-socket-object": {
+    "help": "Instantiation of network interface statement for SMCC tests. (variable name must be net)",
+    "value": "EthernetInterface net"
+},
+"test-socket-connect": {
+    "help": "Network socket connect statement for SMCC tests.",
+    "value": "net.connect();"
+},
+"test-block-device-header-file": {
+    "help": "Name of block device for SMCC tests.",
+    "value": "\"SDBlockDevice.h\""
+},
+"test-block-device-object": {
+    "help": "Block device instantiation for SMCC tests. (variable name must be bd)",
+    "value": "SDBlockDevice bd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);"
+}
+```
+For example, to run the Simple Mbed Cloud Client tests on a `UBLOX_EVK_ODIN_W2`, you would add the following configuration in `target_overrides`:
+ ```json
+"target_overrides": {
+    "UBLOX_EVK_ODIN_W2": {
+        "app.sotp-section-1-address"    : "(0x081C0000)",
+        "app.sotp-section-1-size"       : "(128*1024)",
+        "app.sotp-section-2-address"    : "(0x081E0000)",
+        "app.sotp-section-2-size"       : "(128*1024)",
+        "test-connect-header-file"      : "\"OdinWiFiInterface.h\"",
+        "test-block-device-header-file" : "\"SDBlockDevice.h\"",
+        "test-socket-object"            : "OdinWiFiInterface net;",
+        "test-socket-connect"           : "net.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);",
+        "test-block-device-object"      : "SDBlockDevice bd(D11, D12, D13, D9);"
+    }
+}
+```
+For more examples and a template `mbed_app.json`, see [simple-mbed-cloud-client-template-restricted](https://github.com/ARMmbed/simple-mbed-cloud-client-template-restricted).
 
+4. You may need to delete your `main.cpp`.
+
+5. Run the Simple Mbed Cloud Client tests from the application directory: 
+ ` mbed test -m <platform> -t <toolchain> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*`
 
 ### Known issues
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A simple way of connecting Mbed OS 5 devices to Mbed Cloud. It's designed to:
 * Run separate from your main application, it does not take over your main loop.
 * Provide LWM2M resources, essentially variables that are automatically synced through Mbed Cloud Connect.
 * Help users avoid doing blocking network operations in interrupt contexts, by automatically defering actions to a separate thread.
+* Provide end to end Greentea tests for Mbed Cloud Client
 
 This library is a simpler interface to Mbed Cloud Client, making it trivial to expose sensors, actuators and other variables to the cloud. For a full Mbed Cloud CLient API, check our [documentation](https://cloud.mbed.com/docs/current/mbed-cloud-client/index.html).
 
@@ -55,6 +56,16 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
   There are a number of applications that make usage of the Simple Mbed Cloud Client library.
   
   The Mbed Cloud [Quick-Start](https://cloud.mbed.com/quick-start) is an initiative to support Mbed Partner's platforms while delivering a great User Experience to Mbed Developers.  
+
+### Testing
+
+Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud Client porting efforts. For detailed instructions on how to run the Simple Mbed Cloud Client Tests, see [simple-mbed-cloud-client-template-restricted](https://github.com/armmbed/simple-mbed-cloud-client-template-restricted).
+
+| **Test Name** | **Description** |
+| ------------- | ------------- |
+| `simple-connect` | Tests that the device successfully registers to Mbed Cloud using the specified storage, SOTP, and connectivity configuration. Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID.  |
+
+
 
 ### Known issues
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ When this occurs, you should look at the SOTP sectors defined in `mbed_app.json`
 ```
 Ensure that the sectors are correct according to the flash layout of your device, and they are not being overwritten during the programming of the device. ST-Link devices will overwrite these sectors when using drag-and-drop of .bin files. Thus, moving the SOTP sectors to the end sectors of flash ensure that they will not be overwritten.
 
+#### Stack Overflow
+If you receive a stack overflow error, increase the Mbed OS main stack size to at least 6000. This can be done by modifying the following parameter in `mbed_app.json`:
+```
+ "MBED_CONF_APP_MAIN_STACK_SIZE=6000",
+```
+
+
 ### Known issues
 
 None

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -1,0 +1,57 @@
+"""
+mbed SDK
+Copyright (c) 2011-2013 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from mbed_host_tests import BaseHostTest
+from mbed_cloud.device_directory import DeviceDirectoryAPI
+import os
+
+class SDKTests(BaseHostTest):
+    
+    __result = None
+    deviceApi = None
+    
+    def _callback_device_api_registration(self, key, value, timestamp):
+
+        try:
+            # Check if device is in Mbed Cloud Device Directory
+            device = self.deviceApi.get_device(value)
+            
+            # Send registraton status to device
+            self.send_kv("registration_status", device.state)
+            
+        except:
+            # SDK throws an exception if the device is not found (unsuccessful registration) or times out
+            self.send_kv("registration_status", "error")
+
+    def setup(self):
+        
+        # Register callbacks from GT tests
+        self.register_callback('device_api_registration', self._callback_device_api_registration)
+        
+        # Setup API config
+        api_key_val = os.environ.get("MBED_CLOUD_API_KEY")            
+        api_config = {"api_key" : api_key_val, "host" : "https://api-os2.mbedcloudstaging.net"}
+        
+        # Instantiate Device API
+        self.deviceApi = DeviceDirectoryAPI(api_config)
+        
+        
+    def result(self):
+        return self.__result
+
+    def teardown(self):
+        pass

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -97,7 +97,7 @@ class SDKTests(BaseHostTest):
         
         # Setup API config
         api_key_val = os.environ.get("MBED_CLOUD_API_KEY")            
-        api_config = {"api_key" : api_key_val, "host" : "https://api-os2.mbedcloudstaging.net"}
+        api_config = {"api_key" : api_key_val, "host" : "https://api.us-east-1.mbedcloud.com"}
         
         # Instantiate Device API
         self.deviceApi = DeviceDirectoryAPI(api_config)

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -1,32 +1,69 @@
-"""
-mbed SDK
-Copyright (c) 2011-2013 ARM Limited
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+## ----------------------------------------------------------------------------
+## Copyright 2016-2018 ARM Ltd.
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ----------------------------------------------------------------------------
 
 from mbed_host_tests import BaseHostTest
 from mbed_cloud.device_directory import DeviceDirectoryAPI
 import os
+import time
+
+DEFAULT_CYCLE_PERIOD = 1.0
 
 class SDKTests(BaseHostTest):
     
     __result = None
     deviceApi = None
+    deviceID = None
+    iteration = None
     
+    def test_steps(self):
+        # Step 0 set up test
+        global iteration
+        system_reset = yield
+        
+        # Step 1 device connected to Pelion should reset.
+        self.send_kv('reset', 0)
+        time.sleep(self.program_cycle_s)
+        self.send_kv('__sync', 0)
+        iteration = iteration + 1
+        system_reset = yield   
+        
+        #Step 2, finish
+        yield True
+        
+    def _callback_device_ready(self, key, value, timestamp):
+        # Send device iteration number after a reset
+        global iteration
+        self.send_kv('iteration', iteration)
+    
+    def _callback_advance_test(self, key, value, timestamp):
+        # Advance test sequence
+        try: 
+            if self.test_steps_sequence.send(None):
+                self.notify_complete(True)
+        except (StopIteration, RuntimeError) as exc:
+            self.notify_complete(False)
+        
     def _callback_device_api_registration(self, key, value, timestamp):
-
+        global deviceID
         try:
+            #set value for later use
+            deviceID = value
+            
             # Check if device is in Mbed Cloud Device Directory
             device = self.deviceApi.get_device(value)
             
@@ -36,11 +73,27 @@ class SDKTests(BaseHostTest):
         except:
             # SDK throws an exception if the device is not found (unsuccessful registration) or times out
             self.send_kv("registration_status", "error")
+            
+    def _callback_device_verification(self, key, value, timestamp):
+        global deviceID
+        # Send true if old DeviceID is the same as current device is
+        self.send_kv("verification", (deviceID == value))
+        
+    def _callback_fail_test(self, key, value, timestamp):
+        # Test failed. End it.
+        self.notify_complete(False)
 
     def setup(self):
+        #Start at iteration 0
+        global iteration
+        iteration = 0
         
         # Register callbacks from GT tests
         self.register_callback('device_api_registration', self._callback_device_api_registration)
+        self.register_callback('advance_test', self._callback_advance_test)
+        self.register_callback('device_ready', self._callback_device_ready)
+        self.register_callback('device_verification', self._callback_device_verification)
+        self.register_callback('fail_test', self._callback_fail_test)
         
         # Setup API config
         api_key_val = os.environ.get("MBED_CLOUD_API_KEY")            
@@ -55,3 +108,11 @@ class SDKTests(BaseHostTest):
 
     def teardown(self):
         pass
+    
+    def __init__(self):
+        super(SDKTests, self).__init__()
+        cycle_s = self.get_config_item('program_cycle_s')
+        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
+        
+        self.test_steps_sequence = self.test_steps()
+        self.test_steps_sequence.send(None)

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -1,4 +1,3 @@
-
 #include "mbed.h"
 #include "FATFileSystem.h"
 #include "simple-mbed-cloud-client.h"
@@ -19,98 +18,100 @@
 #include "SDBlockDevice.h"
 #endif
 
-
 using namespace utest::v1;
 
 static const ConnectorClientEndpointInfo* endpointInfo;
 void registered(const ConnectorClientEndpointInfo *endpoint) {
-    printf("Connected to Mbed Cloud. Device ID: %s\n", endpoint->internal_endpoint_name.c_str());
+    printf("Connected to Mbed Cloud. Device ID: %s\n",
+            endpoint->internal_endpoint_name.c_str());
     endpointInfo = endpoint;
 }
 
-void smcc_register(void){
+void smcc_register(void) {
 
     int iteration = 0;
-
-	int timeout = 0;
-	char _key[20] = {};
-	char _value[128] = {};
+    int timeout = 0;
+    char _key[20] = { };
+    char _value[128] = { };
 
     greentea_send_kv("device_ready", true);
     greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
 
     iteration = atoi(_value);
 
-	// Storage definition.
+    // Storage definition.
 #if defined(MBED_CONF_APP_TEST_BLOCK_DEVICE_OBJECT)
-	MBED_CONF_APP_TEST_BLOCK_DEVICE_OBJECT
+    MBED_CONF_APP_TEST_BLOCK_DEVICE_OBJECT
 #else
-	SDBlockDevice bd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);
+    SDBlockDevice bd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO,
+            MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);
 #endif
-	FATFileSystem fs ("sd", &bd);
+    FATFileSystem fs("sd", &bd);
 
-	// Connection definition.
+    // Connection definition.
 #if defined(MBED_CONF_APP_TEST_SOCKET_OBJECT)
-	MBED_CONF_APP_TEST_SOCKET_OBJECT
+    MBED_CONF_APP_TEST_SOCKET_OBJECT
 #else
-	EthernetInterface net;
+    EthernetInterface net;
 #endif
 
 #if defined(MBED_CONF_APP_TEST_SOCKET_CONNECT)
-	nsapi_error_t status = MBED_CONF_APP_TEST_SOCKET_CONNECT
+    nsapi_error_t status = MBED_CONF_APP_TEST_SOCKET_CONNECT
 #else
-	nsapi_error_t status = net.connect();
+    nsapi_error_t status = net.connect();
 #endif
 
-	// Must have IP address.
-	TEST_ASSERT_NOT_EQUAL(net.get_ip_address(), NULL);
-	if (net.get_ip_address() == NULL) {
-		printf("[ERROR] No IP address obtained from network.\r\n");
-		greentea_send_kv("fail_test", 0);
-	}
-	// Connection must be successful.
-	TEST_ASSERT_EQUAL(status, 0);
-	if (status == 0 && net.get_ip_address() != NULL) {
-		printf("[INFO] Connected to network successfully. IP address: %s\n", net.get_ip_address());
-	} else {
-	    printf("[ERROR] Failed to connect to network.\r\n");
-	    greentea_send_kv("fail_test", 0);
-	}
+    // Must have IP address.
+    TEST_ASSERT_NOT_EQUAL(net.get_ip_address(), NULL);
+    if (net.get_ip_address() == NULL) {
+        printf("[ERROR] No IP address obtained from network.\r\n");
+        greentea_send_kv("fail_test", 0);
+    }
 
-	SimpleMbedCloudClient client(&net, &bd, &fs);
+    // Connection must be successful.
+    TEST_ASSERT_EQUAL(status, 0);
+    if (status == 0 && net.get_ip_address() != NULL) {
+        printf("[INFO] Connected to network successfully. IP address: %s\n", net.get_ip_address());
+    } else {
+        printf("[ERROR] Failed to connect to network.\r\n");
+        greentea_send_kv("fail_test", 0);
+    }
+
+    SimpleMbedCloudClient client(&net, &bd, &fs);
 
     if (iteration == 0) {
         printf("[INFO] Resetting storage to a clean state for test.\n");
         client.reformat_storage();
     }
 
-	// SimpleMbedCloudClient initialization must be successful.
-	int client_status = client.init();
-	TEST_ASSERT_EQUAL(client_status, 0);
-	if (client_status == 0) {
-		printf("[INFO] Simple Mbed Cloud Client initialization successful. \r\n");
-	} else {
-	    printf("[ERROR] Simple Mbed Cloud Client failed to initialize.\r\n");
-	    greentea_send_kv("fail_test", 0);
-	}
+    // SimpleMbedCloudClient initialization must be successful.
+    int client_status = client.init();
+    TEST_ASSERT_EQUAL(client_status, 0);
+    if (client_status == 0) {
+        printf("[INFO] Simple Mbed Cloud Client initialization successful. \r\n");
+    } else {
+        printf("[ERROR] Simple Mbed Cloud Client failed to initialize.\r\n");
+        greentea_send_kv("fail_test", 0);
+    }
 
-	client.on_registered(&registered);
-	client.register_and_connect();
+    client.on_registered(&registered);
+    client.register_and_connect();
 
-	timeout = 5000;
-	while (timeout && !client.is_client_registered()) {
-		timeout--;
-		wait_ms(1);
-	}
+    timeout = 5000;
+    while (timeout && !client.is_client_registered()) {
+        timeout--;
+        wait_ms(1);
+    }
 
     // Registration to Mbed Cloud must be successful.
-	TEST_ASSERT_TRUE(client.is_client_registered());
-	if (!client.is_client_registered()) {
-	    printf("[ERROR] Device failed to register.\r\n");
-	    greentea_send_kv("fail_test", 0);
-	} else {
-	    printf("[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
-	}
+    TEST_ASSERT_TRUE(client.is_client_registered());
+    if (!client.is_client_registered()) {
+        printf("[ERROR] Device failed to register.\r\n");
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf(
+                "[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
+    }
 
     // Allow 500ms for Mbed Cloud to update the device directory.
     timeout = 500;
@@ -152,7 +153,6 @@ void smcc_register(void){
     }
 
     // Deregister from Mbed Cloud and disconnect network interface.
-    client.client_unregistered();
     client.close();
     net.disconnect();
 
@@ -169,8 +169,7 @@ void smcc_register(void){
     }
 }
 
-int main(void)
-{
+int main(void) {
     GREENTEA_SETUP(120, "sdk_host_tests");
     smcc_register();
 

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -1,0 +1,54 @@
+/*
+ * mbed Microcontroller Library
+ * Copyright (c) 2006-2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @file fopen.cpp Test cases to POSIX file fopen() interface.
+ *
+ * Please consult the documentation under the test-case functions for
+ * a description of the individual test case.
+ */
+
+#include "mbed.h"
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+using namespace utest::v1;
+
+void smcc_register(void){
+
+	printf("Test is run.");
+    TEST_ASSERT_TRUE(true);
+}
+
+utest::v1::status_t greentea_setup(const size_t number_of_cases)
+{
+
+    GREENTEA_SETUP(30*60, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Simple Cloud Client Register", smcc_register),
+};
+
+Specification specification(greentea_setup, cases);
+
+int main()
+{
+    return !Harness::run(specification);
+}

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -109,8 +109,7 @@ void smcc_register(void) {
         printf("[ERROR] Device failed to register.\r\n");
         greentea_send_kv("fail_test", 0);
     } else {
-        printf(
-                "[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
+        printf("[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
     }
 
     // Allow 500ms for Mbed Cloud to update the device directory.

--- a/mbed-cloud-client.lib
+++ b/mbed-cloud-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-cloud-client/#3137b3d7c8da10bae38749a9384e5e5c77a55012
+https://github.com/ARMmbed/mbed-cloud-client/#9b0bc6a2f3f1f5dbb5be1827db83004d531b99c9

--- a/simple-mbed-cloud-client.h
+++ b/simple-mbed-cloud-client.h
@@ -51,9 +51,9 @@ public:
     MbedCloudClientResource* create_resource(const char *path, const char *name);
     void on_registered(Callback<void(const ConnectorClientEndpointInfo*)> cb);
     void on_unregistered(Callback<void()> cb);
+    int reformat_storage();
 
 private:
-    int reformat_storage();
     void reset_storage();
     int mount_storage();
 


### PR DESCRIPTION
Note: WiP, not ready for merge, various decisions need input.

**What**
A simple Greentea test case for Simple Cloud Client, that tests that the platform is able to register to Mbed Cloud, and uses the Python SDK to confirm that from Mbed Cloud.

**Why**
This can be used by partners and developers as they integrate their platform to be compatible with Mbed Cloud.

**Challenges**
The biggest challenge is to standardize the configurations for each platform. At a bare minimum, each platform will have different:

- Storage
- Connectivity
- SOTP regions

In the future, we will want to test Update, which will also include custom memory definitions for app-starts, potentially larger stack sizes, etc.

Currently, this is being solved by having a set of custom mbed_app.json parameters that must be present for the test to run. This allows the test to be generic for any platform, with sensible defaults, and the ability to customize those parameters with custom connect statements, storage definitions, etc.The customization would happen within the Example Application level, so there is no need to contribute anything directly to SMCC.

An example of an mbed_app.json with these custom statements can be found here: https://github.com/dhwalters423/simple-mbed-cloud-client-example-restricted/blob/smcc_tests_odin/mbed_app.json

There are other ways of solving this issue:
- A /test-config folder inside Simple Cloud Client that holds the configurations for each board, either in one single .json file or a custom .json file for each board. This requires partners to contribute this test configuration when enabling a platform for Mbed Cloud Client.
- A /test-config folder with custom header files that are automatically compiled in based on pre-processor statements (like the current target). Again, this requires partners to contribute these header files for testing.
- Solving this by setting the default values in Mbed OS, potentially within targets.json
- ... **other ideas welcome!** 

**How to Reproduce**
A reproducible test case on the Ublox EVK Odin W2 has been created to test this concept.
Note, you will need the Mbed Cloud Python SDK installed locally.

1. ``mbed import https://github.com/dhwalters423/simple-mbed-cloud-client-example-restricted``
2. ``mbed update smcc_tests_odin``
3. Include your ``mbed_cloud_dev_credentials.c``
4. Modify the Wifi SSID and password in ``mbed_app.json``
5. Set A system environment variable called ``MBED_CLOUD_API_KEY`` with an API key from the account your device will connect to.
6. You may need to remove ``main.cpp``
7. ``mbed test -m UBLOX_EVK_ODIN_W2 -t ARM --app-config mbed_app.json -n simple-mbed-cloud-client-tests-* -v``

**Other considerations**
Currently the host tests are point to https://api-os2.mbedcloudstaging.net, we will want this to point to https://api.mbedcloud.com by default. (just made simpler for testing internally)

