### PR TITLE
Default network and storage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+BUILD/
+mbed-os.lib
+mbed-os/
+mbed_cloud_client_user_config.h

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
     ```
     $ mbed add https://github.com/ARMmbed/simple-mbed-cloud-client
     ```
-    
+
 1. Add your Mbed Cloud developer certificate to your project (`mbed_cloud_dev_credentials.c` file).
 
 1. Reference the library from your main.cpp file, add network and storage drivers; finally initialize the Simple Mbed Cloud Client library.
@@ -29,11 +29,11 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
     #include <Network>
 
     int main() {
-    
+
         /* Initialize connectivity */
         <Network> net;
         net.connect();
-    
+
         /* Initialize storage */
         <Block device> sd(...);
         <Filesystem> fs("sd", &sd);
@@ -42,7 +42,7 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
         SimpleMbedCloudClient client(&net, &sd, &fs);
         client.init();
 
-        /* Create resource */        
+        /* Create resource */
         MbedCloudClientResource *variable;
         variable = client.create_resource("3201/0/5853", "variable");
         variable->set_value("assign new value");
@@ -50,16 +50,16 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
 
     }
     ```
-   
+
 ## Example applications
-  
+
   There are a number of applications that make usage of the Simple Mbed Cloud Client library.
-  
-  The Mbed Cloud [Quick-Start](https://cloud.mbed.com/quick-start) is an initiative to support Mbed Partner's platforms while delivering a great User Experience to Mbed Developers.  
+
+  The Mbed Cloud [Quick-Start](https://cloud.mbed.com/quick-start) is an initiative to support Mbed Partner's platforms while delivering a great User Experience to Mbed Developers.
 
 ## Testing
 
-Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud Client porting efforts. 
+Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud Client porting efforts.
 
 ### Tests
 
@@ -68,31 +68,20 @@ Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud 
 | `simple-connect` | Tests that the device successfully registers to Mbed Cloud using the specified storage, SOTP, and connectivity configuration. Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID.  |
 
 ### Requirements
- Simple Mbed Cloud Client tests rely on the Python SDK to test the end to end solution. 
+ Simple Mbed Cloud Client tests rely on the Python SDK to test the end to end solution.
  To install the Python SDK:
 `pip install mbed-cloud-sdk`
  **Note:** The Python SDK requires Python 2.7.10+ / Python 3.4.3+, built with SSL support.
- 
+
  ### Setup
- 
+
  1. Include the `mbed_cloud_dev_credentials.c` developer certificate in your application. For detailed instructions [see the documentation](https://cloud.mbed.com/docs/current/connecting/provisioning-development-devices.html#creating-and-downloading-a-developer-certificate).
- 
+
  2. Set an environment variable on the host machine called `MBED_CLOUD_API_KEY` which is valid for the account that your device will connect to. For instructions on how to generate an API key, please [see the documentation](https://cloud.mbed.com/docs/current/integrate-web-app/api-keys.html#generating-an-api-key).
- 
+
  3. In your reference application, change the following parameters in `mbed_app.json` to the parameters specific to your platform:
- ```json      
-"test-connect-header-file": {
-    "help": "Name of socket interface for SMCC tests.",
-    "value": "\"EthernetInterface.h\""
-},
-"test-socket-object": {
-    "help": "Instantiation of network interface statement for SMCC tests. (variable name must be net)",
-    "value": "EthernetInterface net;"
-},
-"test-socket-connect": {
-    "help": "Network socket connect statement for SMCC tests.",
-    "value": "net.connect();"
-},
+ ```json
+"target.network-default-interface-type": "ETHERNET",
 "test-block-device-header-file": {
     "help": "Name of block device for SMCC tests.",
     "value": "\"SDBlockDevice.h\""
@@ -110,10 +99,7 @@ For example, to run the Simple Mbed Cloud Client tests on a `UBLOX_EVK_ODIN_W2`,
         "app.sotp-section-1-size"       : "(128*1024)",
         "app.sotp-section-2-address"    : "(0x081E0000)",
         "app.sotp-section-2-size"       : "(128*1024)",
-        "test-connect-header-file"      : "\"OdinWiFiInterface.h\"",
         "test-block-device-header-file" : "\"SDBlockDevice.h\"",
-        "test-socket-object"            : "OdinWiFiInterface net;",
-        "test-socket-connect"           : "net.connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);",
         "test-block-device-object"      : "SDBlockDevice bd(D11, D12, D13, D9);"
     }
 }
@@ -122,9 +108,9 @@ For more examples and a template `mbed_app.json`, see [simple-mbed-cloud-client-
 
 4. You may need to delete your `main.cpp`.
 
-5. Run the Simple Mbed Cloud Client tests from the application directory: 
- ` mbed test -m <platform> -t <toolchain> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*`
- 
+5. Run the Simple Mbed Cloud Client tests from the application directory:
+ ` mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*`
+
 ### Troubleshooting
 Below are a list of common issues and fixes for using Simple Mbed Cloud Client.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Simple Mbed Cloud Client
+# Simple Pelion Device Management Client
+
+(aka Simple Mbed Cloud Client)
 
 A simple way of connecting Mbed OS 5 devices to Mbed Cloud. It's designed to:
 
@@ -18,9 +20,9 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
     $ mbed add https://github.com/ARMmbed/simple-mbed-cloud-client
     ```
 
-1. Add your Mbed Cloud developer certificate to your project (`mbed_cloud_dev_credentials.c` file).
+2. Add your Mbed Cloud developer certificate to your project (`mbed_cloud_dev_credentials.c` file).
 
-1. Reference the library from your main.cpp file, add network and storage drivers; finally initialize the Simple Mbed Cloud Client library.
+3. Reference the library from your main.cpp file, add network and storage drivers; finally initialize the Simple Mbed Cloud Client library.
 
     ```cpp
     #include "simple-mbed-cloud-client.h"
@@ -79,36 +81,20 @@ Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud 
 
  2. Set an environment variable on the host machine called `MBED_CLOUD_API_KEY` which is valid for the account that your device will connect to. For instructions on how to generate an API key, please [see the documentation](https://cloud.mbed.com/docs/current/integrate-web-app/api-keys.html#generating-an-api-key).
 
- 3. In your reference application, change the following parameters in `mbed_app.json` to the parameters specific to your platform:
+ 3. If your platform does not have a default network interface in `targets.json`, you can define this in `mbed_app.json`, for example:
  ```json
 "target.network-default-interface-type": "ETHERNET",
-"test-block-device-header-file": {
-    "help": "Name of block device for SMCC tests.",
-    "value": "\"SDBlockDevice.h\""
-},
-"test-block-device-object": {
-    "help": "Block device instantiation for SMCC tests. (variable name must be bd)",
-    "value": "SDBlockDevice bd(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);"
-}
 ```
-For example, to run the Simple Mbed Cloud Client tests on a `UBLOX_EVK_ODIN_W2`, you would add the following configuration in `target_overrides`:
- ```json
-"target_overrides": {
-    "UBLOX_EVK_ODIN_W2": {
-        "app.sotp-section-1-address"    : "(0x081C0000)",
-        "app.sotp-section-1-size"       : "(128*1024)",
-        "app.sotp-section-2-address"    : "(0x081E0000)",
-        "app.sotp-section-2-size"       : "(128*1024)",
-        "test-block-device-header-file" : "\"SDBlockDevice.h\"",
-        "test-block-device-object"      : "SDBlockDevice bd(D11, D12, D13, D9);"
-    }
-}
+
+1. If your platform does not have a default storage component in `targets.json`, you can define this in `mbed_app.json`. Aditionally, you may want to double-check the storage pinout configuration for your platform in the `mbed_lib.json` file in `mbed-os/components/storage/blockdevice/`.
+   
+
 ```
-For more examples and a template `mbed_app.json`, see [simple-mbed-cloud-client-template-restricted](https://github.com/ARMmbed/simple-mbed-cloud-client-template-restricted).
+For examples of platform configuration, see the applications available in the [Quick-start](https://cloud.mbed.com/quick-start).
 
-4. You may need to delete your `main.cpp`.
+1. You may need to delete your `main.cpp`.
 
-5. Run the Simple Mbed Cloud Client tests from the application directory:
+2. Run the Simple Mbed Cloud Client tests from the application directory:
  ` mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*`
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
 
 | **Test Name** | **Description** |
 | ------------- | ------------- |
-| `simple-connect` | Tests that the device successfully registers to Mbed Cloud using the specified storage, SOTP, and connectivity configuration. Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID.  |
+| `simple-connect` | - Tests that the device successfully registers to Mbed Cloud using the specified storage, SOTP, and connectivity configuration. <br> - Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID. <br> |
 
 ### Requirements
  Simple Pelion Client tests rely on the Python SDK to test the end to end solution.
@@ -77,23 +77,24 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
 
  ### Setup
 
- 1. Include the `mbed_cloud_dev_credentials.c` developer certificate in your application. For detailed instructions [see the documentation](https://cloud.mbed.com/docs/current/connecting/provisioning-development-devices.html#creating-and-downloading-a-developer-certificate).
+ 1. Import an Simple Pelion Client application that contains the corresponding configuration in `mbed_app.json`. The application will include this Simple Pelion Client library.
 
- 2. Set an environment variable on the host machine called `MBED_CLOUD_API_KEY` which is valid for the account that your device will connect to. For instructions on how to generate an API key, please [see the documentation](https://cloud.mbed.com/docs/current/integrate-web-app/api-keys.html#generating-an-api-key).
-
- 3. If your platform does not have a default network interface in `targets.json`, you can define this in `mbed_app.json`, for example:
- ```json
-"target.network-default-interface-type": "ETHERNET",
-```
-
-1. If your platform does not have a default storage component in `targets.json`, you can define this in `mbed_app.json`. Aditionally, you may want to double-check the storage pinout configuration for your platform in the `mbed_lib.json` file in `mbed-os/components/storage/blockdevice/`.
+    For examples of platform configuration, see the applications available in the [Quick-start](https://cloud.mbed.com/quick-start).
    
-For examples of platform configuration, see the applications available in the [Quick-start](https://cloud.mbed.com/quick-start).
+ 2. Include the `mbed_cloud_dev_credentials.c` developer certificate in your application. For detailed instructions [see the documentation](https://cloud.mbed.com/docs/current/connecting/provisioning-development-devices.html#creating-and-downloading-a-developer-certificate).
 
-1. You may need to delete your `main.cpp`.
+ 3. Set an `mbed config` variable `CLOUD_SDK_API_KEY` on the host machine valid for the account that your device will connect to. For example:
 
-2. Run the Simple Pelion Client tests from the application directory:
- ` mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*`
+     ```mbed config -G CLOUD_SDK_API_KEY <API_KEY>```
+
+     For instructions on how to generate an API key, please [see the documentation](https://cloud.mbed.com/docs/current/integrate-web-app/api-keys.html#generating-an-api-key).
+
+   
+ 4. You may need to delete your `main.cpp`.
+
+ 5. Run the Simple Pelion Client tests from the application directory:
+
+     ```mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*```
 
 ### Troubleshooting
 Below are a list of common issues and fixes for using Simple Pelion Client.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 (aka Simple Mbed Cloud Client)
 
-A simple way of connecting Mbed OS 5 devices to Mbed Cloud. It's designed to:
+A simple way of connecting Mbed OS 5 devices to Arm Pelion Device Management. It's designed to:
 
-* Enable Mbed Cloud Connect and mbed Cloud Update to applications in few lines of code.
+* Enables applications to connect and perform firmware updates in few lines of code.
 * Run separate from your main application, it does not take over your main loop.
-* Provide LWM2M resources, essentially variables that are automatically synced through Mbed Cloud Connect.
+* Provide LWM2M resources, essentially variables that are automatically synced through Pelion Client.
 * Help users avoid doing blocking network operations in interrupt contexts, by automatically defering actions to a separate thread.
-* Provide end to end Greentea tests for Mbed Cloud Client
+* Provide end to end Greentea tests for Pelion Client
 
-This library is a simpler interface to Mbed Cloud Client, making it trivial to expose sensors, actuators and other variables to the cloud. For a full Mbed Cloud CLient API, check our [documentation](https://cloud.mbed.com/docs/current/mbed-cloud-client/index.html).
+This library is a simpler interface to Pelion Cloud Client, making it trivial to expose sensors, actuators and other variables to the cloud. For a full Pelion CLient API, check our [documentation](https://cloud.mbed.com/docs/current/mbed-cloud-client/index.html).
 
-## Usage to Connect to Mbed Cloud
+## Usage to Connect to Pelion Device Management
 
 1. Add this library to your Mbed OS project:
 
@@ -20,7 +20,7 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
     $ mbed add https://github.com/ARMmbed/simple-mbed-cloud-client
     ```
 
-2. Add your Mbed Cloud developer certificate to your project (`mbed_cloud_dev_credentials.c` file).
+2. Add your Pelion developer certificate to your project (`mbed_cloud_dev_credentials.c` file).
 
 3. Reference the library from your main.cpp file, add network and storage drivers; finally initialize the Simple Pelion Client library. The is the architecture of a generic Simple Pelion Client application:
 
@@ -57,7 +57,7 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
 
   There are a number of applications that make usage of the Simple Pelion Client library.
 
-  The Mbed Cloud [Quick-Start](https://cloud.mbed.com/quick-start) is an initiative to support Mbed Partner's platforms while delivering a great User Experience to Mbed Developers.
+  The Pelion [Quick-Start](https://cloud.mbed.com/quick-start) is an initiative to support Mbed Partner's platforms while delivering a great User Experience to Mbed Developers.
 
 ## Testing
 
@@ -67,7 +67,7 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
 
 | **Test Name** | **Description** |
 | ------------- | ------------- |
-| `simple-connect` | - Tests that the device successfully registers to Mbed Cloud using the specified storage, SOTP, and connectivity configuration. <br> - Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID. <br> |
+| `simple-connect` | - Tests that the device successfully registers to Pelion Device Management using the specified storage, SOTP, and connectivity configuration. <br> - Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID. <br> |
 
 ### Requirements
  Simple Pelion Client tests rely on the Python SDK to test the end to end solution.
@@ -106,7 +106,7 @@ This is due to an issue with the storage block device. If using an SD card, ensu
 Occasionally, if the test failed during a previous attempt, the SMCC Greentea tests will fail to sync. If this is the case, please replug your device to the host PC. Additionally, you may need to update your DAPLink or ST-Link interface firmware.
 
 #### Device identity is inconsistent
-If your device ID in Mbed Cloud is inconsistent over a device reset, it could be because it is failing to open the credentials on the storage held in the Enhanced Secure File System. Typically, this is because the device cannot access the Root of Trust stored in SOTP.
+If your device ID in Pelion Device Management is inconsistent over a device reset, it could be because it is failing to open the credentials on the storage held in the Enhanced Secure File System. Typically, this is because the device cannot access the Root of Trust stored in SOTP.
 
 One way to verify this is to see if Simple Pelion Client autoformats the storage after a device reset when `format-storage-layer-on-error` is set to `1` in `mbed_app.json`.  It would appear on the serial terminal output from the device as the following:
 ```
@@ -132,9 +132,9 @@ If you receive a stack overflow error, increase the Mbed OS main stack size to a
 ```
 
 #### Device failed to register
-Check the device allocation on your Mbed Cloud account to see if you are allowed additional devices to connect. You can delete development devices, after being deleted they will not count towards your allocation.
+Check the device allocation on your Pelion account to see if you are allowed additional devices to connect. You can delete development devices, after being deleted they will not count towards your allocation.
 
 
 ### Known issues
 
-None
+Check open issues on [GitHub](https://github.com/ARMmbed/simple-mbed-cloud-client/issues)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
 
 2. Add your Mbed Cloud developer certificate to your project (`mbed_cloud_dev_credentials.c` file).
 
-3. Reference the library from your main.cpp file, add network and storage drivers; finally initialize the Simple Mbed Cloud Client library.
+3. Reference the library from your main.cpp file, add network and storage drivers; finally initialize the Simple Pelion Client library. The is the architecture of a generic Simple Pelion Client application:
 
     ```cpp
     #include "simple-mbed-cloud-client.h"
@@ -40,7 +40,7 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
         <Block device> sd(...);
         <Filesystem> fs("sd", &sd);
 
-        /* Initialize Simple Mbed Cloud Client */
+        /* Initialize Simple Pelion Client */
         SimpleMbedCloudClient client(&net, &sd, &fs);
         client.init();
 
@@ -55,13 +55,13 @@ This library is a simpler interface to Mbed Cloud Client, making it trivial to e
 
 ## Example applications
 
-  There are a number of applications that make usage of the Simple Mbed Cloud Client library.
+  There are a number of applications that make usage of the Simple Pelion Client library.
 
   The Mbed Cloud [Quick-Start](https://cloud.mbed.com/quick-start) is an initiative to support Mbed Partner's platforms while delivering a great User Experience to Mbed Developers.
 
 ## Testing
 
-Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud Client porting efforts.
+Simple Pelion Client provides Greentea tests to test your porting efforts.
 
 ### Tests
 
@@ -70,7 +70,7 @@ Simple Mbed Cloud Client provides Greentea tests to test your Simple Mbed Cloud 
 | `simple-connect` | Tests that the device successfully registers to Mbed Cloud using the specified storage, SOTP, and connectivity configuration. Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID.  |
 
 ### Requirements
- Simple Mbed Cloud Client tests rely on the Python SDK to test the end to end solution.
+ Simple Pelion Client tests rely on the Python SDK to test the end to end solution.
  To install the Python SDK:
 `pip install mbed-cloud-sdk`
  **Note:** The Python SDK requires Python 2.7.10+ / Python 3.4.3+, built with SSL support.
@@ -94,11 +94,11 @@ For examples of platform configuration, see the applications available in the [Q
 
 1. You may need to delete your `main.cpp`.
 
-2. Run the Simple Mbed Cloud Client tests from the application directory:
+2. Run the Simple Pelion Client tests from the application directory:
  ` mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*`
 
 ### Troubleshooting
-Below are a list of common issues and fixes for using Simple Mbed Cloud Client.
+Below are a list of common issues and fixes for using Simple Pelion Client.
 
 #### Autoformatting failed with error -5005
 This is due to an issue with the storage block device. If using an SD card, ensure that the SD card is seated properly.
@@ -109,12 +109,12 @@ Occasionally, if the test failed during a previous attempt, the SMCC Greentea te
 #### Device identity is inconsistent
 If your device ID in Mbed Cloud is inconsistent over a device reset, it could be because it is failing to open the credentials on the storage held in the Enhanced Secure File System. Typically, this is because the device cannot access the Root of Trust stored in SOTP.
 
-One way to verify this is to see if Simple Mbed Cloud Client autoformats the storage after a device reset when `format-storage-layer-on-error` is set to `1` in `mbed_app.json`.  It would appear on the serial terminal output from the device as the following:
+One way to verify this is to see if Simple Pelion Client autoformats the storage after a device reset when `format-storage-layer-on-error` is set to `1` in `mbed_app.json`.  It would appear on the serial terminal output from the device as the following:
 ```
-[Simple Cloud Client] Initializing storage.
-[Simple Cloud Client] Autoformatting the storage.
-[Simple Cloud Client] Reset storage to an empty state.
-[Simple Cloud Client] Starting developer flow
+[SMCC] Initializing storage.
+[SMCC] Autoformatting the storage.
+[SMCC] Reset storage to an empty state.
+[SMCC] Starting developer flow
 ```
 
 When this occurs, you should look at the SOTP sectors defined in `mbed_app.json`:

--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
 
 1. If your platform does not have a default storage component in `targets.json`, you can define this in `mbed_app.json`. Aditionally, you may want to double-check the storage pinout configuration for your platform in the `mbed_lib.json` file in `mbed-os/components/storage/blockdevice/`.
    
-
-```
 For examples of platform configuration, see the applications available in the [Quick-start](https://cloud.mbed.com/quick-start).
 
 1. You may need to delete your `main.cpp`.

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -105,7 +105,7 @@ class SDKTests(BaseHostTest):
             return -1
 
         result = str(result).split(' ')
-        if len(result) == 0:
+        if result[1] == "No":
             print "Error: MBED_CLOUD_SDK_CONFIG global config is not set."
             return -1
 

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -20,6 +20,7 @@ from mbed_host_tests import BaseHostTest
 from mbed_cloud.device_directory import DeviceDirectoryAPI
 import os
 import time
+import subprocess
 
 DEFAULT_CYCLE_PERIOD = 1.0
 
@@ -96,12 +97,26 @@ class SDKTests(BaseHostTest):
         self.register_callback('fail_test', self._callback_fail_test)
         
         # Setup API config
-        api_key_val = os.environ.get("MBED_CLOUD_API_KEY")            
+        try:
+            result = subprocess.check_output(["mbed", "config", "-G", "MBED_CLOUD_SDK_CONFIG"], \
+                                              stderr=subprocess.STDOUT)
+        except Exception, e:
+            print "Error: MBED_CLOUD_SDK_CONFIG global config is not set: " + str(e)
+            return -1
+
+        result = str(result).split(' ')
+        if len(result) == 0:
+            print "Error: MBED_CLOUD_SDK_CONFIG global config is not set."
+            return -1
+
+        # Get API KEY and remove LF char if included
+        api_key_val = str(result[1]).rstrip()
+        print "MBED_CLOUD_SDK_CONFIG: " + api_key_val 
+
         api_config = {"api_key" : api_key_val, "host" : "https://api.us-east-1.mbedcloud.com"}
         
         # Instantiate Device API
         self.deviceApi = DeviceDirectoryAPI(api_config)
-        
         
     def result(self):
         return self.__result

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -140,10 +140,6 @@ void smcc_register(void) {
         }
     }
 
-    // Deregister from Mbed Cloud and disconnect network interface.
-    client.close();
-    net->disconnect();
-
     // Reset on first iteration of test.
     if (iteration == 0) {
         printf("[INFO] Resetting device.\r\n");

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -32,14 +32,17 @@ void smcc_register(void) {
     iteration = atoi(_value);
 
     // Connection definition.
-#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == "ETHERNET"
-    NetworkInterface *net;
-    net = NetworkInterface::get_default_instance();
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET
+    NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t status = net->connect();
-#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == "WIFI"
-    WiFiInterface *net;
-    net = WiFiInterface::get_default_instance();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI
+    WiFiInterface *net = WiFiInterface::get_default_instance();
     nsapi_error_t status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
+    CellularBase *net = CellularBase::get_default_instance();
+    ccellular->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
+    cellular->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
+    nsapi_error_t status = net->connect();
 #else
     #error "Default network interface not defined"
 #endif
@@ -152,7 +155,7 @@ void smcc_register(void) {
 }
 
 int main(void) {
-    GREENTEA_SETUP(120, "sdk_host_tests");
+    GREENTEA_SETUP(150, "sdk_host_tests");
     smcc_register();
 
     return 0;

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -43,6 +43,9 @@ void smcc_register(void) {
     ccellular->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
     cellular->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
     nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    MeshInterface *net = MeshInterface::get_default_instance();;
+    nsapi_error_t status = net->connect();
 #else
     #error "Default network interface not defined"
 #endif

--- a/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client.cpp
@@ -96,7 +96,7 @@ int SimpleMbedCloudClient::init() {
     // Initialize the FCC
     fcc_status_e fcc_status = fcc_init();
     if(fcc_status != FCC_STATUS_SUCCESS) {
-        printf("[Simple Cloud Client] Factory Client Configuration failed with status %d. \n", fcc_status);
+        printf("[SMCC] Factory Client Configuration failed with status %d. \n", fcc_status);
         return 1;
     }
 
@@ -105,7 +105,7 @@ int SimpleMbedCloudClient::init() {
     if (fcc_status == FCC_STATUS_KCM_STORAGE_ERROR) {
         int mount_result = mount_storage();
         if (mount_result != 0) {
-            printf("[Simple Cloud Client] Failed to mount file system with status %d. \n", mount_result);
+            printf("[SMCC] Failed to mount file system with status %d. \n", mount_result);
 #if !defined(MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR) || MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR == 0
             return 1;
 #endif
@@ -128,7 +128,7 @@ int SimpleMbedCloudClient::init() {
     }
 #else
     if (fcc_status != FCC_STATUS_SUCCESS) {
-        printf("[Simple Cloud Client] Device not configured for mbed Cloud - try re-formatting your storage device or set MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR to 1\n");
+        printf("[SMCC] Device not configured for mbed Cloud - try re-formatting your storage device or set MBED_CONF_APP_FORMAT_STORAGE_LAYER_ON_ERROR to 1\n");
         return 1;
     }
 #endif
@@ -147,22 +147,22 @@ int SimpleMbedCloudClient::init() {
     palStatus_t status = PAL_SUCCESS;
     status = pal_fsRmFiles(DEFAULT_FIRMWARE_PATH);
     if(status == PAL_SUCCESS) {
-        printf("[Simple Cloud Client] Firmware storage erased.\n");
+        printf("[SMCC] Firmware storage erased.\n");
     } else if (status == PAL_ERR_FS_NO_PATH) {
-        printf("[Simple Cloud Client] Firmware path not found/does not exist.\n");
+        printf("[SMCC] Firmware path not found/does not exist.\n");
     } else {
-        printf("[Simple Cloud Client] Firmware storage erasing failed with %" PRId32, status);
+        printf("[SMCC] Firmware storage erasing failed with %" PRId32, status);
         return 1;
     }
 #endif
 
 #if MBED_CONF_APP_DEVELOPER_MODE == 1
-    printf("[Simple Cloud Client] Starting developer flow\n");
+    printf("[SMCC] Starting developer flow\n");
     fcc_status = fcc_developer_flow();
     if (fcc_status == FCC_STATUS_KCM_FILE_EXIST_ERROR) {
-        printf("[Simple Cloud Client] Developer credentials already exist\n");
+        printf("[SMCC] Developer credentials already exist\n");
     } else if (fcc_status != FCC_STATUS_SUCCESS) {
-        printf("[Simple Cloud Client] Failed to load developer credentials - is the storage device active and accessible?\n");
+        printf("[SMCC] Failed to load developer credentials - is the storage device active and accessible?\n");
         return 1;
     }
 #endif
@@ -181,7 +181,7 @@ bool SimpleMbedCloudClient::call_register() {
     bool setup = _cloud_client.setup(_net);
     _register_called = true;
     if (!setup) {
-        printf("[Simple Cloud Client] Client setup failed\n");
+        printf("[SMCC] Client setup failed\n");
         return false;
     }
 
@@ -318,9 +318,9 @@ void SimpleMbedCloudClient::error(int error_code) {
     }
 
     // @todo: move this into user space
-    printf("\n[Simple Cloud Client] Error occurred : %s\n", error);
-    printf("[Simple Cloud Client] Error code : %d\n", error_code);
-    printf("[Simple Cloud Client] Error details : %s\n",_cloud_client.error_description());
+    printf("\n[SMCC] Error occurred : %s\n", error);
+    printf("[SMCC] Error code : %d\n", error_code);
+    printf("[SMCC] Error details : %s\n",_cloud_client.error_description());
 }
 
 bool SimpleMbedCloudClient::is_client_registered() {
@@ -353,7 +353,7 @@ bool SimpleMbedCloudClient::register_and_connect() {
 
     // Print memory statistics if the MBED_HEAP_STATS_ENABLED is defined.
     #ifdef MBED_HEAP_STATS_ENABLED
-        printf("[Simple Cloud Client] Register being called\r\n");
+        printf("[SMCC] Register being called\r\n");
         heap_stats();
     #endif
 
@@ -381,11 +381,11 @@ MbedCloudClientResource* SimpleMbedCloudClient::create_resource(const char *path
 int SimpleMbedCloudClient::reformat_storage()
 {
     int reformat_result = -1;
-    printf("[Simple Cloud Client] Autoformatting the storage.\n");
+    printf("[SMCC] Autoformatting the storage.\n");
     if (_bd) {
         reformat_result = _fs->reformat(_bd);
         if (reformat_result != 0) {
-            printf("[Simple Cloud Client] Autoformatting failed with error %d\n", reformat_result);
+            printf("[SMCC] Autoformatting failed with error %d\n", reformat_result);
         }
     }
     return reformat_result;
@@ -393,17 +393,17 @@ int SimpleMbedCloudClient::reformat_storage()
 
 void SimpleMbedCloudClient::reset_storage()
 {
-    printf("[Simple Cloud Client] Reset storage to an empty state.\n");
+    printf("[SMCC] Reset storage to an empty state.\n");
     fcc_status_e delete_status = fcc_storage_delete();
     if (delete_status != FCC_STATUS_SUCCESS) {
-        printf("[Simple Cloud Client] Failed to delete storage - %d\n", delete_status);
+        printf("[SMCC] Failed to delete storage - %d\n", delete_status);
     }
 }
 
 int SimpleMbedCloudClient::mount_storage()
 {
     int mount_result = -1;
-    printf("[Simple Cloud Client] Initializing storage.\n");
+    printf("[SMCC] Initializing storage.\n");
     if (_bd) {
         mount_result = _fs->mount(_bd);
     }


### PR DESCRIPTION
Mbed OS 5.10 includes default network interfaces and storage block device drivers for platforms.

This PR introduces changes to:
- Update test configuration to use the default configuration
- Documentation & rebranding updates

Note, continues to be based on (MCC) Pelion Client library v1.4.0

This PR precedes the SMCC application here:

cc @dhwalters423 @bridadan @janjongboom

Please review asap - we aim to merge this today