### PR TITLE
LwM2M GET+PUT tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
 
    
  4. Compile the tests with the `MBED_TEST_MODE` compilation flag.
+    
     ```mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-* -DMBED_TEST_MODE --compile```
 
  5. Run the Simple Pelion Client tests from the application directory:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
 
 | **Test Name** | **Description** |
 | ------------- | ------------- |
-| `simple-connect` | - Tests that the device successfully registers to Pelion Device Management using the specified storage, SOTP, and connectivity configuration. <br> - Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID. <br> |
+| `simple-connect` | - Tests that the device successfully registers to Pelion Device Management using the specified storage, SOTP, and connectivity configuration. <br> - Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID. <br> -Verifies GET and PUT LwM2M resource functionality on the device. |
 
 ### Requirements
  Simple Pelion Client tests rely on the Python SDK to test the end to end solution.
@@ -83,14 +83,15 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
    
  2. Include the `mbed_cloud_dev_credentials.c` developer certificate in your application. For detailed instructions [see the documentation](https://cloud.mbed.com/docs/current/connecting/provisioning-development-devices.html#creating-and-downloading-a-developer-certificate).
 
- 3. Set an `mbed config` variable `CLOUD_SDK_API_KEY` on the host machine valid for the account that your device will connect to. For example:
+ 3. Set a gobal `mbed config` variable `CLOUD_SDK_API_KEY` on the host machine valid for the account that your device will connect to. For example:
 
      ```mbed config -G CLOUD_SDK_API_KEY <API_KEY>```
 
      For instructions on how to generate an API key, please [see the documentation](https://cloud.mbed.com/docs/current/integrate-web-app/api-keys.html#generating-an-api-key).
 
    
- 4. You may need to delete your `main.cpp`.
+ 4. Compile the tests with the `MBED_TEST_MODE` compilation flag.
+    ````mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-* -DMBED_TEST_MODE --compile``
 
  5. Run the Simple Pelion Client tests from the application directory:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
    
  2. Include the `mbed_cloud_dev_credentials.c` developer certificate in your application. For detailed instructions [see the documentation](https://cloud.mbed.com/docs/current/connecting/provisioning-development-devices.html#creating-and-downloading-a-developer-certificate).
 
- 3. Set a gobal `mbed config` variable `CLOUD_SDK_API_KEY` on the host machine valid for the account that your device will connect to. For example:
+ 3. Set a global `mbed config` variable `CLOUD_SDK_API_KEY` on the host machine valid for the account that your device will connect to. For example:
 
      ```mbed config -G CLOUD_SDK_API_KEY <API_KEY>```
 
@@ -91,11 +91,11 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
 
    
  4. Compile the tests with the `MBED_TEST_MODE` compilation flag.
-    ````mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-* -DMBED_TEST_MODE --compile``
+    ```mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-* -DMBED_TEST_MODE --compile```
 
  5. Run the Simple Pelion Client tests from the application directory:
 
-     ```mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-*```
+     ```mbed test -t <toolchain> -m <platform> --app-config mbed_app.json -n simple-mbed-cloud-client-tests-* --run -v```
 
 ### Troubleshooting
 Below are a list of common issues and fixes for using Simple Pelion Client.

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -18,6 +18,7 @@
 
 from mbed_host_tests import BaseHostTest
 from mbed_cloud.device_directory import DeviceDirectoryAPI
+from mbed_cloud.connect import ConnectAPI
 import os
 import time
 import subprocess
@@ -28,6 +29,7 @@ class SDKTests(BaseHostTest):
     
     __result = None
     deviceApi = None
+    connectApi = None
     deviceID = None
     iteration = None
     
@@ -83,6 +85,20 @@ class SDKTests(BaseHostTest):
     def _callback_fail_test(self, key, value, timestamp):
         # Test failed. End it.
         self.notify_complete(False)
+        
+    def _callback_device_lwm2m_get_verification(self, key, value, timestamp):
+        global deviceID
+        
+        resource_value = self.connectApi.get_resource_value(deviceID, value)
+        
+        self.send_kv("res_value", resource_value)
+    
+    def _callback_device_lwm2m_put_verification(self, key, value, timestamp):
+        global deviceID
+        
+        resource_value = self.connectApi.set_resource_value(deviceID, value, "test1put")
+        
+        self.send_kv("res_set", "test1put");
 
     def setup(self):
         #Start at iteration 0
@@ -95,6 +111,8 @@ class SDKTests(BaseHostTest):
         self.register_callback('device_ready', self._callback_device_ready)
         self.register_callback('device_verification', self._callback_device_verification)
         self.register_callback('fail_test', self._callback_fail_test)
+        self.register_callback('device_lwm2m_get_test', self._callback_device_lwm2m_get_verification)
+        self.register_callback('device_lwm2m_put_test', self._callback_device_lwm2m_put_verification)
         
         # Setup API config
         try:
@@ -115,8 +133,9 @@ class SDKTests(BaseHostTest):
 
         api_config = {"api_key" : api_key_val, "host" : "https://api.us-east-1.mbedcloud.com"}
         
-        # Instantiate Device API
+        # Instantiate Device and Connect API
         self.deviceApi = DeviceDirectoryAPI(api_config)
+        self.connectApi = ConnectAPI(api_config)
         
     def result(self):
         return self.__result

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -89,16 +89,24 @@ class SDKTests(BaseHostTest):
     def _callback_device_lwm2m_get_verification(self, key, value, timestamp):
         global deviceID
         
+        # Get resource value from device
         resource_value = self.connectApi.get_resource_value(deviceID, value)
         
+        # Send resource value back to device
         self.send_kv("res_value", resource_value)
     
     def _callback_device_lwm2m_put_verification(self, key, value, timestamp):
         global deviceID
         
-        resource_value = self.connectApi.set_resource_value(deviceID, value, "test1put")
+        # Get resource value from device and increment it
+        resource_value = self.connectApi.get_resource_value(deviceID, value)
+        updated_value = int(resource_value) + 5  
         
-        self.send_kv("res_set", "test1put");
+        # Set new resource value from cloud
+        self.connectApi.set_resource_value(deviceID, value, updated_value)
+
+        # Send new resource value to device for verification.
+        self.send_kv("res_set", updated_value);
 
     def setup(self):
         #Start at iteration 0

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -93,7 +93,7 @@ void smcc_register(void) {
     MbedCloudClientResource *res_put_test;
     res_put_test = client.create_resource("5000/0/2", "put_resource");
     res_put_test->methods(M2MMethod::PUT | M2MMethod::GET);
-    res_put_test->set_value("test0");
+    res_put_test->set_value(1);
 
     client.on_registered(&registered);
     client.register_and_connect();
@@ -153,6 +153,8 @@ void smcc_register(void) {
 
         // LwM2M tests
         printf("[INFO] Beginning LwM2M resource tests.\r\n");
+        int current_res_value;
+        int updated_res_value;
 
         // Read orignal value of /5000/0/1
         greentea_send_kv("device_lwm2m_get_test", "/5000/0/1");
@@ -177,11 +179,17 @@ void smcc_register(void) {
             printf("[INFO] Changed value of LwM2M resource /5000/0/1 is observed correctly. \r\n");
         }
 
-        // Update resource /5000/0/2 from cloud and confirm value is correct on client
+        // Observe resource /5000/0/2 from cloud, add +10, and confirm value is correct on client
         greentea_send_kv("device_lwm2m_put_test", "/5000/0/2");
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
-        TEST_ASSERT_EQUAL_STRING(_value, res_put_test->get_value().c_str());
-        if (strcmp(_value, res_put_test->get_value().c_str()) != 0) {
+
+        // Get current value and updated value
+        updated_res_value = atoi(_value);
+        current_res_value = res_put_test->get_value_int();
+
+        // Ensure current value and updated value are equal
+        TEST_ASSERT_EQUAL(updated_res_value, current_res_value);
+        if (updated_res_value != current_res_value) {
             printf("[ERROR] Wrong value read from device after resource update.\r\n");
             greentea_send_kv("fail_test", 0);
         } else {

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -40,11 +40,11 @@ void smcc_register(void) {
     nsapi_error_t status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
 #elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
     CellularBase *net = CellularBase::get_default_instance();
-    ccellular->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
-    cellular->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
+    net->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
+    net->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
     nsapi_error_t status = net->connect();
 #elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
-    MeshInterface *net = MeshInterface::get_default_instance();;
+    MeshInterface *net = MeshInterface::get_default_instance();
     nsapi_error_t status = net->connect();
 #else
     #error "Default network interface not defined"


### PR DESCRIPTION
Tests the creation, GET and PUT operations of LwM2M resources on the device using the Python SDK Connect API.

Creates 2 LwM2M resources on the device and performs the following functionality:

- Reads the initial value of /5000/0/1 from the Python SDK
- Update the value of /5000/0/1 and observe change from Python SDK
- Reads the initial value of /5000/0/2, increments it by 5, PUTs the new incremented value to /5000/0/2, and verifies change was made to device.

This is ready for merge.

**Future enhancements**
Things planned for the future: 

Splitting this to 4 different tests (CONNECT, CONSISTENT ID, GET, PUT)
POST test verifying callback functionality on device.
