### PR TITLE
Greentea tests: Separate tests for each test case

### DIFF
--- a/TESTS/connect/register/main.cpp
+++ b/TESTS/connect/register/main.cpp
@@ -1,0 +1,128 @@
+#include "mbed.h"
+#include "FATFileSystem.h"
+#include "simple-mbed-cloud-client.h"
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+using namespace utest::v1;
+
+// Default storage definition.
+BlockDevice* bd = BlockDevice::get_default_instance();
+FATFileSystem fs("sd", bd);
+
+static const ConnectorClientEndpointInfo* endpointInfo;
+void registered(const ConnectorClientEndpointInfo *endpoint) {
+    printf("[INFO] Connected to Pelion Device Management. Device ID: %s\n",
+            endpoint->internal_endpoint_name.c_str());
+    endpointInfo = endpoint;
+}
+
+void smcc_register(void) {
+
+    int timeout = 0;
+    bool test_result = true;
+    char _key[20] = { };
+    char _value[128] = { };
+
+    // Connection definition.
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET
+    NetworkInterface *net = NetworkInterface::get_default_instance();
+    nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI
+    WiFiInterface *net = WiFiInterface::get_default_instance();
+    nsapi_error_t status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
+    CellularBase *net = CellularBase::get_default_instance();
+    net->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
+    net->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
+    nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    MeshInterface *net = MeshInterface::get_default_instance();
+    nsapi_error_t status = net->connect();
+#else
+    #error "Default network interface not defined"
+#endif
+
+    // Must have IP address.
+    TEST_ASSERT_NOT_EQUAL(net->get_ip_address(), NULL);
+    if (net->get_ip_address() == NULL) {
+        printf("[ERROR] No IP address obtained from network.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    // Connection must be successful.
+    TEST_ASSERT_EQUAL(status, 0);
+    if (status == 0 && net->get_ip_address() != NULL) {
+        printf("[INFO] Connected to network successfully. IP address: %s\n", net->get_ip_address());
+    } else {
+        printf("[ERROR] Failed to connect to network.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    SimpleMbedCloudClient client(net, bd, &fs);
+
+    // SimpleMbedCloudClient initialization must be successful.
+    int client_status = client.init();
+    TEST_ASSERT_EQUAL(client_status, 0);
+    if (client_status == 0) {
+        printf("[INFO] Simple Mbed Cloud Client initialization successful. \r\n");
+    } else {
+        printf("[ERROR] Simple Mbed Cloud Client failed to initialize.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    client.on_registered(&registered);
+    client.register_and_connect();
+
+    timeout = 5000;
+    while (timeout && !client.is_client_registered()) {
+        timeout--;
+        wait_ms(1);
+    }
+
+    // Registration to Mbed Cloud must be successful.
+    TEST_ASSERT_TRUE(client.is_client_registered());
+    if (!client.is_client_registered()) {
+        printf("[ERROR] Device failed to register.\r\n");
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
+    }
+
+    // Allow 500ms for Mbed Cloud to update the device directory.
+    timeout = 500;
+    while (timeout) {
+        timeout--;
+        wait_ms(1);
+    }
+
+    // Start host tests with device id
+    printf("[INFO] Starting Mbed Cloud verification using Python SDK...\r\n");
+    greentea_send_kv("device_api_registration", endpointInfo->internal_endpoint_name.c_str());
+
+    // Wait for Host Test and API response (blocking here)
+    greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+
+    // Ensure the state is 'registered' in the Device Directory
+    TEST_ASSERT_EQUAL_STRING("registered", _value);
+    if (strcmp(_value, "registered") != 0) {
+        printf("[ERROR] Device could not be verified as registered in Device Directory.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] Device is registered in the Device Directory.\r\n");
+    }
+
+    GREENTEA_TESTSUITE_RESULT(test_result);
+}
+
+int main(void) {
+    GREENTEA_SETUP(150, "sdk_host_tests");
+    smcc_register();
+    return 0;
+}

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -82,15 +82,18 @@ class SDKTests(BaseHostTest):
         # Send true if old DeviceID is the same as current device is
         self.send_kv("verification", (deviceID == value))
         
-    def _callback_fail_test(self, key, value, timestamp):
-        # Test failed. End it.
-        self.notify_complete(False)
+    def _callback_complete_test(self, key, value, timestamp):
+        # Test completed. End it.
+        
+        if int(value) is not 0:
+            self.notify_complete(False)
+        else:
+            self.notify_complete(True)
         
     def _callback_device_lwm2m_get_verification(self, key, value, timestamp):
-        global deviceID
-        
+
         # Get resource value from device
-        resource_value = self.connectApi.get_resource_value(deviceID, value)
+        resource_value = self.connectApi.get_resource_value(value, '/5000/0/1')
         
         # Send resource value back to device
         self.send_kv("res_value", resource_value)
@@ -99,20 +102,19 @@ class SDKTests(BaseHostTest):
         global deviceID
         
         # Get resource value from device and increment it
-        resource_value = self.connectApi.get_resource_value(deviceID, value)
+        resource_value = self.connectApi.get_resource_value(value, '/5000/0/2')
         updated_value = int(resource_value) + 5  
         
         # Set new resource value from cloud
-        self.connectApi.set_resource_value(deviceID, value, updated_value)
+        self.connectApi.set_resource_value(value, '/5000/0/2', updated_value)
 
         # Send new resource value to device for verification.
         self.send_kv("res_set", updated_value);
         
     def _callback_device_lwm2m_post_verification(self, key, value, timestamp):
-        global deviceID
         
         # Execute POST function on device
-        resource_value = self.connectApi.execute_resource(deviceID, value)
+        resource_value = self.connectApi.execute_resource(value, '/5000/0/3')
         
     def _callback_device_lwm2m_post_verification_result(self, key, value, timestamp):
         
@@ -129,7 +131,7 @@ class SDKTests(BaseHostTest):
         self.register_callback('advance_test', self._callback_advance_test)
         self.register_callback('device_ready', self._callback_device_ready)
         self.register_callback('device_verification', self._callback_device_verification)
-        self.register_callback('fail_test', self._callback_fail_test)
+        self.register_callback('complete_test', self._callback_complete_test)
         self.register_callback('device_lwm2m_get_test', self._callback_device_lwm2m_get_verification)
         self.register_callback('device_lwm2m_put_test', self._callback_device_lwm2m_put_verification)
         self.register_callback('device_lwm2m_post_test', self._callback_device_lwm2m_post_verification)

--- a/TESTS/lwm2m/get/main.cpp
+++ b/TESTS/lwm2m/get/main.cpp
@@ -1,0 +1,149 @@
+#include "mbed.h"
+#include "FATFileSystem.h"
+#include "simple-mbed-cloud-client.h"
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+using namespace utest::v1;
+
+// Default storage definition.
+BlockDevice* bd = BlockDevice::get_default_instance();
+FATFileSystem fs("sd", bd);
+
+static const ConnectorClientEndpointInfo* endpointInfo;
+void registered(const ConnectorClientEndpointInfo *endpoint) {
+    printf("[INFO] Connected to Pelion Device Management. Device ID: %s\n",
+            endpoint->internal_endpoint_name.c_str());
+    endpointInfo = endpoint;
+}
+
+void smcc_lwm2m_get(void) {
+
+    int timeout = 0;
+    bool test_result = true;
+    char _key[20] = { };
+    char _value[128] = { };
+
+    // Connection definition.
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET
+    NetworkInterface *net = NetworkInterface::get_default_instance();
+    nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI
+    WiFiInterface *net = WiFiInterface::get_default_instance();
+    nsapi_error_t status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
+    CellularBase *net = CellularBase::get_default_instance();
+    net->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
+    net->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
+    nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    MeshInterface *net = MeshInterface::get_default_instance();
+    nsapi_error_t status = net->connect();
+#else
+    #error "Default network interface not defined"
+#endif
+
+    // Must have IP address.
+    TEST_ASSERT_NOT_EQUAL(net->get_ip_address(), NULL);
+    if (net->get_ip_address() == NULL) {
+        printf("[ERROR] No IP address obtained from network.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    // Connection must be successful.
+    TEST_ASSERT_EQUAL(status, 0);
+    if (status == 0 && net->get_ip_address() != NULL) {
+        printf("[INFO] Connected to network successfully. IP address: %s\n", net->get_ip_address());
+    } else {
+        printf("[ERROR] Failed to connect to network.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    SimpleMbedCloudClient client(net, bd, &fs);
+
+    // SimpleMbedCloudClient initialization must be successful.
+    int client_status = client.init();
+    TEST_ASSERT_EQUAL(client_status, 0);
+    if (client_status == 0) {
+        printf("[INFO] Simple Mbed Cloud Client initialization successful. \r\n");
+    } else {
+        printf("[ERROR] Simple Mbed Cloud Client failed to initialize.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    //Create LwM2M resources
+    MbedCloudClientResource *res_get_test;
+    res_get_test = client.create_resource("5000/0/1", "get_resource");
+    res_get_test->observable(true);
+    res_get_test->methods(M2MMethod::GET);
+    res_get_test->set_value("test0");
+
+    client.on_registered(&registered);
+    client.register_and_connect();
+
+    timeout = 5000;
+    while (timeout && !client.is_client_registered()) {
+        timeout--;
+        wait_ms(1);
+    }
+
+    // Registration to Mbed Cloud must be successful.
+    TEST_ASSERT_TRUE(client.is_client_registered());
+    if (!client.is_client_registered()) {
+        printf("[ERROR] Device failed to register.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
+    }
+
+    // Allow 500ms for Mbed Cloud to update the device directory.
+    timeout = 500;
+    while (timeout) {
+        timeout--;
+        wait_ms(1);
+    }
+
+    // LwM2M tests
+    printf("[INFO] Beginning LwM2M resource GET test.\r\n");
+
+    // Read original value of /5000/0/1
+    greentea_send_kv("device_lwm2m_get_test", endpointInfo->internal_endpoint_name.c_str());
+    greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+    TEST_ASSERT_EQUAL_STRING("test0", _value);
+    if (strcmp(_value, "test0") != 0) {
+        printf("[ERROR] Wrong value reported in Pelion DM.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] Original value of LwM2M resource /5000/0/1 is read correctly. \r\n");
+    }
+
+    // Update resource /5000/0/1 from client and observe value
+    greentea_send_kv("device_lwm2m_get_test", endpointInfo->internal_endpoint_name.c_str());
+    res_get_test->set_value("test1");
+    greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+    TEST_ASSERT_EQUAL_STRING("test1", _value);
+    if (strcmp(_value, "test1") != 0) {
+        printf("[ERROR] Wrong value observed from Pelion DM.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] Changed value of LwM2M resource /5000/0/1 is observed correctly. \r\n");
+    }
+
+    GREENTEA_TESTSUITE_RESULT(test_result);
+
+}
+
+int main(void) {
+    GREENTEA_SETUP(150, "sdk_host_tests");
+    smcc_lwm2m_get();
+
+    return 0;
+}

--- a/TESTS/lwm2m/post/main.cpp
+++ b/TESTS/lwm2m/post/main.cpp
@@ -1,0 +1,143 @@
+#include "mbed.h"
+#include "FATFileSystem.h"
+#include "simple-mbed-cloud-client.h"
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+using namespace utest::v1;
+
+// Default storage definition.
+BlockDevice* bd = BlockDevice::get_default_instance();
+FATFileSystem fs("sd", bd);
+
+static const ConnectorClientEndpointInfo* endpointInfo;
+void registered(const ConnectorClientEndpointInfo *endpoint) {
+    printf("[INFO] Connected to Pelion Device Management. Device ID: %s\n",
+            endpoint->internal_endpoint_name.c_str());
+    endpointInfo = endpoint;
+}
+
+void post_test_callback(MbedCloudClientResource *resource, const uint8_t *buffer, uint16_t size) {
+    printf("[INFO] POST test callback executed. \r\n");
+    greentea_send_kv("device_lwm2m_post_test_result", 0);
+}
+
+void smcc_lwm2m_post(void) {
+
+    int timeout = 0;
+    int result = -1;
+    bool test_result = true;
+    char _key[20] = { };
+    char _value[128] = { };
+
+    // Connection definition.
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET
+    NetworkInterface *net = NetworkInterface::get_default_instance();
+    nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI
+    WiFiInterface *net = WiFiInterface::get_default_instance();
+    nsapi_error_t status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
+    CellularBase *net = CellularBase::get_default_instance();
+    net->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
+    net->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
+    nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    MeshInterface *net = MeshInterface::get_default_instance();
+    nsapi_error_t status = net->connect();
+#else
+    #error "Default network interface not defined"
+#endif
+
+    // Must have IP address.
+    TEST_ASSERT_NOT_EQUAL(net->get_ip_address(), NULL);
+    if (net->get_ip_address() == NULL) {
+        printf("[ERROR] No IP address obtained from network.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    // Connection must be successful.
+    TEST_ASSERT_EQUAL(status, 0);
+    if (status == 0 && net->get_ip_address() != NULL) {
+        printf("[INFO] Connected to network successfully. IP address: %s\n", net->get_ip_address());
+    } else {
+        printf("[ERROR] Failed to connect to network.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    SimpleMbedCloudClient client(net, bd, &fs);
+
+    // SimpleMbedCloudClient initialization must be successful.
+    int client_status = client.init();
+    TEST_ASSERT_EQUAL(client_status, 0);
+    if (client_status == 0) {
+        printf("[INFO] Simple Mbed Cloud Client initialization successful. \r\n");
+    } else {
+        printf("[ERROR] Simple Mbed Cloud Client failed to initialize.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    //Create LwM2M resources
+    MbedCloudClientResource *res_post_test;
+    res_post_test = client.create_resource("5000/0/3", "post_resource");
+    res_post_test->methods(M2MMethod::POST);
+    res_post_test->attach_post_callback(post_test_callback);
+
+    client.on_registered(&registered);
+    client.register_and_connect();
+
+    timeout = 5000;
+    while (timeout && !client.is_client_registered()) {
+        timeout--;
+        wait_ms(1);
+    }
+
+    // Registration to Mbed Cloud must be successful.
+    TEST_ASSERT_TRUE(client.is_client_registered());
+    if (!client.is_client_registered()) {
+        printf("[ERROR] Device failed to register.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
+    }
+
+    // Allow 500ms for Mbed Cloud to update the device directory.
+    timeout = 500;
+    while (timeout) {
+        timeout--;
+        wait_ms(1);
+    }
+
+    // LwM2M tests
+    printf("[INFO] Beginning LwM2M resource POST test.\r\n");
+
+    printf("[INFO] Executing POST on /5000/0/3 and waiting for callback function.");
+    greentea_send_kv("device_lwm2m_post_test", endpointInfo->internal_endpoint_name.c_str());
+    greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+
+    // Ensure that callback is executed. If not, test fails.
+    result = atoi(_value);
+    TEST_ASSERT_EQUAL(0, result);
+    if (result != 0) {
+        printf("[ERROR] POST callback execution failed on resource /5000/0/3. \r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] POST callback executed successfully /5000/0/3 \r\n");
+    }
+
+    GREENTEA_TESTSUITE_RESULT(test_result);
+}
+
+int main(void) {
+    GREENTEA_SETUP(150, "sdk_host_tests");
+    smcc_lwm2m_post();
+
+    return 0;
+}

--- a/TESTS/lwm2m/put/main.cpp
+++ b/TESTS/lwm2m/put/main.cpp
@@ -1,0 +1,143 @@
+#include "mbed.h"
+#include "FATFileSystem.h"
+#include "simple-mbed-cloud-client.h"
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+using namespace utest::v1;
+
+// Default storage definition.
+BlockDevice* bd = BlockDevice::get_default_instance();
+FATFileSystem fs("sd", bd);
+
+static const ConnectorClientEndpointInfo* endpointInfo;
+void registered(const ConnectorClientEndpointInfo *endpoint) {
+    printf("[INFO] Connected to Pelion Device Management. Device ID: %s\n",
+            endpoint->internal_endpoint_name.c_str());
+    endpointInfo = endpoint;
+}
+
+void smcc_lwm2m_put(void) {
+
+    int timeout = 0;
+    bool test_result = true;
+    char _key[20] = { };
+    char _value[128] = { };
+
+    // Connection definition.
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET
+    NetworkInterface *net = NetworkInterface::get_default_instance();
+    nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI
+    WiFiInterface *net = WiFiInterface::get_default_instance();
+    nsapi_error_t status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
+    CellularBase *net = CellularBase::get_default_instance();
+    net->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
+    net->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
+    nsapi_error_t status = net->connect();
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    MeshInterface *net = MeshInterface::get_default_instance();
+    nsapi_error_t status = net->connect();
+#else
+    #error "Default network interface not defined"
+#endif
+
+    // Must have IP address.
+    TEST_ASSERT_NOT_EQUAL(net->get_ip_address(), NULL);
+    if (net->get_ip_address() == NULL) {
+        printf("[ERROR] No IP address obtained from network.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    // Connection must be successful.
+    TEST_ASSERT_EQUAL(status, 0);
+    if (status == 0 && net->get_ip_address() != NULL) {
+        printf("[INFO] Connected to network successfully. IP address: %s\n", net->get_ip_address());
+    } else {
+        printf("[ERROR] Failed to connect to network.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    SimpleMbedCloudClient client(net, bd, &fs);
+
+    // SimpleMbedCloudClient initialization must be successful.
+    int client_status = client.init();
+    TEST_ASSERT_EQUAL(client_status, 0);
+    if (client_status == 0) {
+        printf("[INFO] Simple Mbed Cloud Client initialization successful. \r\n");
+    } else {
+        printf("[ERROR] Simple Mbed Cloud Client failed to initialize.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    }
+
+    //Create LwM2M resources
+    MbedCloudClientResource *res_put_test;
+    res_put_test = client.create_resource("5000/0/2", "put_resource");
+    res_put_test->methods(M2MMethod::PUT | M2MMethod::GET);
+    res_put_test->set_value(1);
+
+    client.on_registered(&registered);
+    client.register_and_connect();
+
+    timeout = 5000;
+    while (timeout && !client.is_client_registered()) {
+        timeout--;
+        wait_ms(1);
+    }
+
+    // Registration to Mbed Cloud must be successful.
+    TEST_ASSERT_TRUE(client.is_client_registered());
+    if (!client.is_client_registered()) {
+        printf("[ERROR] Device failed to register.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
+    }
+
+    // Allow 500ms for Mbed Cloud to update the device directory.
+    timeout = 500;
+    while (timeout) {
+        timeout--;
+        wait_ms(1);
+    }
+
+    // LwM2M tests
+    printf("[INFO] Beginning LwM2M resource PUT test.\r\n");
+    int current_res_value;
+    int updated_res_value;
+
+
+    // Observe resource /5000/0/2 from cloud, add +10, and confirm value is correct on client
+    greentea_send_kv("device_lwm2m_put_test", endpointInfo->internal_endpoint_name.c_str());
+    greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+
+    // Get current value and updated value
+    updated_res_value = atoi(_value);
+    current_res_value = res_put_test->get_value_int();
+
+    // Ensure current value and updated value are equal
+    TEST_ASSERT_EQUAL(updated_res_value, current_res_value);
+    if (updated_res_value != current_res_value) {
+        printf("[ERROR] Wrong value read from device after resource update.\r\n");
+        test_result = false;
+        greentea_send_kv("fail_test", 0);
+    } else {
+        printf("[INFO] Value of resource /5000/0/2 successfully changed from the cloud using PUT. \r\n");
+    }
+
+    GREENTEA_TESTSUITE_RESULT(test_result);
+}
+
+int main(void) {
+    GREENTEA_SETUP(150, "sdk_host_tests");
+    smcc_lwm2m_put();
+
+    return 0;
+}


### PR DESCRIPTION
Seperates out the tests into 5 distinct tests:

Register - confirms registration to Pelion
Identity - comfirms registration to Pelion and a consistent identity across reset (tests SOTP config)
LwM2M GET - creates GET resource and observes it
LwM2M PUT - creates PUT resource and sets new value
LwM2M POST - creates POST resources and executes it.

```
mbedgt: test suite report:
+----------+---------------+-------------------------------------------------+--------+--------------------+-------------+
| target   | platform_name | test suite                                      | result | elapsed_time (sec) | copy_method |
+----------+---------------+-------------------------------------------------+--------+--------------------+-------------+
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-connect-identity | OK     | 116.6              | default     |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-connect-register | OK     | 80.38              | default     |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-lwm2m-get        | OK     | 80.99              | default     |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-lwm2m-post       | OK     | 81.22              | default     |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-lwm2m-put        | OK     | 81.67              | default     |
+----------+---------------+-------------------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 5 OK
mbedgt: test case report:
+----------+---------------+-------------------------------------------------+-------------------------------------------------+--------+--------+--------+---                               -----------------+
| target   | platform_name | test suite                                      | test case                                       | passed | failed | result | el                               apsed_time (sec) |
+----------+---------------+-------------------------------------------------+-------------------------------------------------+--------+--------+--------+---                               -----------------+
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-connect-identity | simple-mbed-cloud-client-tests-connect-identity | 1      | 0      | OK     | 11                               6.6              |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-connect-register | simple-mbed-cloud-client-tests-connect-register | 1      | 0      | OK     | 80                               .38              |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-lwm2m-get        | simple-mbed-cloud-client-tests-lwm2m-get        | 1      | 0      | OK     | 80                               .99              |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-lwm2m-post       | simple-mbed-cloud-client-tests-lwm2m-post       | 1      | 0      | OK     | 81                               .22              |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-lwm2m-put        | simple-mbed-cloud-client-tests-lwm2m-put        | 1      | 0      | OK     | 81                               .67              |
+----------+---------------+-------------------------------------------------+-------------------------------------------------+--------+--------+--------+---                               -----------------+
mbedgt: test case results: 5 OK
```

//TODO:

Needs documentation.

// Outstanding issues:
Each test creates a new device in Pelion because GT uses .bin files which do not support sector preservation (so credentials are rewritten each test). This results in 5 new devices in Pelion each time all tests are ran. We could use the Python SDK to delete the device from Pelion after test is ran.

The LwM2M GET PUT and POST tests all end in hardfault, EVEN if the test is successful. For example:

```
[1538585658.78][CONN][INF] found KV pair in stream: {{end;success}}, queued...
[1538585658.80][CONN][RXD]
[1538585658.80][CONN][RXD] ++ MbedOS Fault Handler ++
[1538585658.80][CONN][RXD]
[1538585658.80][CONN][RXD] FaultType: HardFault
[1538585658.80][HTST][ERR] orphan event in main phase: {{max_heap_usage;0}}, timestamp=1538585658.778000
[1538585658.80][CONN][RXD]
[1538585658.80][HTST][ERR] orphan event in main phase: {{reserved_heap;0}}, timestamp=1538585658.778000
[1538585658.80][CONN][RXD] Context:
[1538585658.80][CONN][RXD] R0   : 0000008C
[1538585658.80][CONN][RXD] R1   : 35470048
[1538585658.80][CONN][RXD] R2   : 2001549C
[1538585658.80][CONN][RXD] R3   : 20015014
[1538585658.80][CONN][RXD] R4   : 00000001
[1538585658.80][HTST][INF] __notify_complete(True)
[1538585658.80][CONN][RXD] R5   : 2000FBF8
[1538585658.80][HTST][INF] __exit_event_queue received
[1538585658.80][CONN][RXD] R6   : 0000008C
[1538585658.80][HTST][INF] test suite run finished after 44.89 sec...
[1538585658.80][CONN][RXD] R7   : 00000094
[1538585658.80][CONN][RXD] R8   : 00000006
[1538585658.80][CONN][RXD] R9   : 20015408
[1538585658.80][CONN][INF] found KV pair in stream: {{__exit;0}}, queued...
[1538585658.80][CONN][INF] received special event '__host_test_finished' value='True', finishing
[1538585658.86][HTST][INF] CONN exited with code: 0
[1538585658.86][HTST][INF] Some events in queue
[1538585658.86][HTST][INF] stopped consuming events
[1538585658.86][HTST][INF] host test result() call skipped, received: True
[1538585658.86][HTST][WRN] missing __exit event from DUT
[1538585658.86][HTST][INF] calling blocking teardown()
[1538585658.86][HTST][INF] teardown() finished
[1538585658.86][HTST][INF] {{result;success}}
```
My investigation thus far says it is a problem with the LwM2M resources themselves. The register test does not have this behaviour and does not include any LwM2M resources. On the LwM2M resources themselves if you comment out the resource creation the hard fault does not occur. Something to do with shutting down the client with LwM2M resource objects. Needs further investigation.