### PR TITLE
Separate test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,16 @@ Simple Pelion Client provides Greentea tests to test your porting efforts.
 
 | **Test Name** | **Description** |
 | ------------- | ------------- |
-| `simple-connect` | - Tests that the device successfully registers to Pelion Device Management using the specified storage, SOTP, and connectivity configuration. <br> - Tests that SOTP and the RoT is preserved over a reset and the device connects with a consistent device ID. <br> - Verifies GET, PUT, and POST (callback) LwM2M resource functionality on the device. |
+| `simple-connect` | Test suite name for the following tests. |
+| `Connect to network` | Tests the connection to the network via network interface. |
+| `Format storage` | Tests that a successful storage format occurs and storage is configured correctly. |
+| `Simple Mbed Cloud Client Initialization` | Verifies that SMCC can be initialized with the given network, storage, and filesystem configuration. This is where the FCU and KCM configuration is written to storage and the Root of Trust is written to SOTP. |
+| `Pelion Device Management Register` | Confirms the device is registered to Pelion from the client. |
+| `Device registration in Device Directory` | Verifies that a registered device appears in the Device Directory in Pelion Device Management. |
+| `Consistent Identity` | Confirms that the device identity is preserved over a device reset, confirming that Root of Trust is stored in SOTP correctly. |
+| `LwM2M GET Test` | Confirms that Pelion can perform a GET request on an LwM2M resource, and observe the value changing. |
+| `LwM2M PUT Test` | Confirms that Pelion can perform a PUT request on an LwM2M resource by setting a new value. |
+| `LwM2M POST Test` | Confirms that Pelion can execute a POST on an LwM2M resource and the callback function on the device is called. |
 
 ### Requirements
  Simple Pelion Client tests rely on the Python SDK to test the end to end solution.

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -107,6 +107,17 @@ class SDKTests(BaseHostTest):
 
         # Send new resource value to device for verification.
         self.send_kv("res_set", updated_value);
+        
+    def _callback_device_lwm2m_post_verification(self, key, value, timestamp):
+        global deviceID
+        
+        # Execute POST function on device
+        resource_value = self.connectApi.execute_resource(deviceID, value)
+        
+    def _callback_device_lwm2m_post_verification_result(self, key, value, timestamp):
+        
+        # Called from callback function on device, POST function working as expected.
+        self.send_kv("post_test_executed", 0)
 
     def setup(self):
         #Start at iteration 0
@@ -121,6 +132,8 @@ class SDKTests(BaseHostTest):
         self.register_callback('fail_test', self._callback_fail_test)
         self.register_callback('device_lwm2m_get_test', self._callback_device_lwm2m_get_verification)
         self.register_callback('device_lwm2m_put_test', self._callback_device_lwm2m_put_verification)
+        self.register_callback('device_lwm2m_post_test', self._callback_device_lwm2m_post_verification)
+        self.register_callback('device_lwm2m_post_test_result', self._callback_device_lwm2m_post_verification_result)
         
         # Setup API config
         try:

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -19,6 +19,11 @@ void registered(const ConnectorClientEndpointInfo *endpoint) {
     endpointInfo = endpoint;
 }
 
+void post_test_callback(MbedCloudClientResource *resource, const uint8_t *buffer, uint16_t size) {
+    printf("[INFO] POST test callback executed. \r\n");
+    greentea_send_kv("device_lwm2m_post_test_result", 0);
+}
+
 void smcc_register(void) {
 
     int iteration = 0;
@@ -31,55 +36,73 @@ void smcc_register(void) {
 
     iteration = atoi(_value);
 
+
+    // Start network connection test.
+    GREENTEA_TESTCASE_START("Connect to network");
+    printf("[INFO] Attempting to connect to network.\r\n");
+
     // Connection definition.
 #if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET
     NetworkInterface *net = NetworkInterface::get_default_instance();
-    nsapi_error_t status = net->connect();
+    nsapi_error_t net_status = net->connect();
 #elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI
     WiFiInterface *net = WiFiInterface::get_default_instance();
-    nsapi_error_t status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
+    nsapi_error_t net_status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
 #elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
     CellularBase *net = CellularBase::get_default_instance();
     net->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
     net->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
-    nsapi_error_t status = net->connect();
+    nsapi_error_t net_status = net->connect();
 #elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
     MeshInterface *net = MeshInterface::get_default_instance();
-    nsapi_error_t status = net->connect();
+    nsapi_error_t net_status = net->connect();
 #else
     #error "Default network interface not defined"
 #endif
 
-    // Must have IP address.
-    TEST_ASSERT_NOT_EQUAL(net->get_ip_address(), NULL);
-    if (net->get_ip_address() == NULL) {
-        printf("[ERROR] No IP address obtained from network.\r\n");
-        greentea_send_kv("fail_test", 0);
-    }
+    GREENTEA_TESTCASE_FINISH("Connect to network", (net_status == 0), (net_status != 0));
 
-    // Connection must be successful.
-    TEST_ASSERT_EQUAL(status, 0);
-    if (status == 0 && net->get_ip_address() != NULL) {
-        printf("[INFO] Connected to network successfully. IP address: %s\n", net->get_ip_address());
+    // Report status to console.
+    if (net_status != 0) {
+        printf("[ERROR] Device failed to connect to network.\r\n");
+        // End the test early, cannot continue without network connection.
+        greentea_send_kv("fail_test", 0);
     } else {
-        printf("[ERROR] Failed to connect to network.\r\n");
-        greentea_send_kv("fail_test", 0);
+        printf("[INFO] Connected to network successfully. IP address: %s\n", net->get_ip_address());
     }
 
+    // Instantiate SimpleMbedCloudClient.
     SimpleMbedCloudClient client(net, bd, &fs);
 
+    // This must be done on the first iteration to ensure that we can test writing of new credentials. It may
+    // happen twice if the reset storage flag is set to 1.
     if (iteration == 0) {
+
         printf("[INFO] Resetting storage to a clean state for test.\n");
-        client.reformat_storage();
+
+        GREENTEA_TESTCASE_START("Format storage");
+        int storage_status = client.reformat_storage();
+        GREENTEA_TESTCASE_FINISH("Format storage", (storage_status == 0), (storage_status != 0));
+
+        // Report status to console.
+        if (storage_status == 0) {
+            printf("[INFO] Storage format successful. \r\n");
+        } else {
+            printf("[ERROR] Storage format failed..\r\n");
+        }
     }
 
     // SimpleMbedCloudClient initialization must be successful.
+    GREENTEA_TESTCASE_START("Simple Mbed Cloud Client Initialization");
     int client_status = client.init();
-    TEST_ASSERT_EQUAL(client_status, 0);
+    GREENTEA_TESTCASE_FINISH("Simple Mbed Cloud Client Initialization", (client_status == 0), (client_status != 0));
+
+    // Report status to console.
     if (client_status == 0) {
         printf("[INFO] Simple Mbed Cloud Client initialization successful. \r\n");
     } else {
         printf("[ERROR] Simple Mbed Cloud Client failed to initialize.\r\n");
+        // End the test early, cannot continue without successful cloud client initialization.
         greentea_send_kv("fail_test", 0);
     }
 
@@ -95,7 +118,17 @@ void smcc_register(void) {
     res_put_test->methods(M2MMethod::PUT | M2MMethod::GET);
     res_put_test->set_value(1);
 
+    MbedCloudClientResource *res_post_test;
+    res_post_test = client.create_resource("5000/0/3", "post_resource");
+    res_post_test->methods(M2MMethod::POST);
+    res_post_test->attach_post_callback(post_test_callback);
+
+    // Set client callback to report endpoint name.
     client.on_registered(&registered);
+
+    // Register to Pelion Device Management.
+    GREENTEA_TESTCASE_START("Pelion Device Management Register");
+
     client.register_and_connect();
 
     timeout = 5000;
@@ -104,14 +137,17 @@ void smcc_register(void) {
         wait_ms(1);
     }
 
-    // Registration to Mbed Cloud must be successful.
-    TEST_ASSERT_TRUE(client.is_client_registered());
-    if (!client.is_client_registered()) {
-        printf("[ERROR] Device failed to register.\r\n");
-        greentea_send_kv("fail_test", 0);
-    } else {
+    // Get registration status.
+    bool client_registered = client.is_client_registered();
+    if (client_registered) {
+        client_status = 0;
         printf("[INFO] Simple Mbed Cloud Client successfully registered to Mbed Cloud.\r\n");
+    } else {
+        printf("[ERROR] Device failed to register.\r\n");
+        client_status = -1;
+        greentea_send_kv("fail_test", 0);
     }
+    GREENTEA_TESTCASE_FINISH("Pelion Device Management Register", (client_status == 0), (client_status != 0));
 
     // Allow 500ms for Mbed Cloud to update the device directory.
     timeout = 500;
@@ -121,6 +157,12 @@ void smcc_register(void) {
     }
 
     if (iteration == 0) {
+
+        //Start registration status test
+        GREENTEA_TESTCASE_START("Device registration in Device Directory");
+
+        int registration_status;
+
         // Start host tests with device id
         printf("[INFO] Starting Mbed Cloud verification using Python SDK...\r\n");
         greentea_send_kv("device_api_registration", endpointInfo->internal_endpoint_name.c_str());
@@ -128,73 +170,156 @@ void smcc_register(void) {
         // Wait for Host Test and API response (blocking here)
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
 
-        // Ensure the state is 'registered' in the Device Directory
-        TEST_ASSERT_EQUAL_STRING("registered", _value);
-        if (strcmp(_value, "registered") != 0) {
-            printf("[ERROR] Device could not be verified as registered in Device Directory.\r\n");
-            greentea_send_kv("fail_test", 0);
+        if (strcmp(_key, "registration_status") == 0) {
+            if (strcmp(_value, "registered") == 0) {
+                registration_status = 0;
+                printf("[INFO] Device is registered in the Device Directory. \r\n");
+            } else {
+                registration_status = -1;
+                printf("[ERROR] Device could not be verified as registered in Device Directory.\r\n");
+            }
         } else {
-            printf("[INFO] Device is registered in the Device Directory.\r\n");
+            printf("[ERROR] Wrong value reported from test.\r\n");
+            greentea_send_kv("fail_test", 0);
         }
 
+        GREENTEA_TESTCASE_FINISH("Device registration in Device Directory", (registration_status == 0), (registration_status != 0));
+
     } else {
+
+        //Start consistent identity test.
+        GREENTEA_TESTCASE_START("Consistent Identity");
+
+        int identity_status;
+
         printf("[INFO] Verifying consistent Device ID...\r\n");
         greentea_send_kv("device_verification", endpointInfo->internal_endpoint_name.c_str());
 
         // Wait for Host Test to verify consistent device ID (blocking here)
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
-        TEST_ASSERT_EQUAL_STRING("True", _value);
-        if (strcmp(_value, "True") != 0) {
-            printf("[ERROR] Device ID is inconsistent. SOTP and Secure Storage was not preserved.\r\n");
-            greentea_send_kv("fail_test", 0);
+
+        if (strcmp(_key, "verification") == 0) {
+            if (strcmp(_value, "True") == 0) {
+                identity_status = 0;
+                printf("[INFO] Device ID consistent, SOTP and Secure Storage is preserved correctly.\r\n");
+            } else {
+                printf("Value is %s \r\n", _value);
+                identity_status = -1;
+                printf("[ERROR] Device ID is inconsistent. SOTP and Secure Storage was not preserved.\r\n");
+            }
         } else {
-            printf("[INFO] Device ID consistent, SOTP and Secure Storage is preserved correctly.\r\n");
+            printf("[ERROR] Wrong value reported from test.\r\n");
+            greentea_send_kv("fail_test", 0);
         }
+
+        GREENTEA_TESTCASE_FINISH("Consistent Identity", (identity_status == 0), (identity_status != 0));
 
         // LwM2M tests
         printf("[INFO] Beginning LwM2M resource tests.\r\n");
+
+        // GET test
+        GREENTEA_TESTCASE_START("LwM2M GET Test");
+
+        int get_status;
+
+        // Read original value of /5000/0/1
+        greentea_send_kv("device_lwm2m_get_test", "/5000/0/1");
+
+        // Wait for Host Test to verify it read the value and send it back.
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+
+        if (strcmp(_key, "res_value") == 0) {
+            if (strcmp(_value, "test0") == 0) {
+                get_status = 0;
+                printf("[INFO] Original value of LwM2M resource /5000/0/1 is read correctly \r\n");
+            } else {
+                get_status = -1;
+                printf("[ERROR] Wrong value reported in Pelion DM.\r\n");
+            }
+        } else {
+            printf("[ERROR] Wrong value reported from test.\r\n");
+            greentea_send_kv("fail_test", 0);
+        }
+
+        // First GET test must be successful first.
+        if (get_status == 0) {
+            // Update resource /5000/0/1 from client and observe value
+            greentea_send_kv("device_lwm2m_get_test", "/5000/0/1");
+            res_get_test->set_value("test1");
+
+            // Wait for Host Test to verify it read the value and send it back.
+            greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+
+            if (strcmp(_key, "res_value") == 0) {
+                if (strcmp(_value, "test1") == 0) {
+                    get_status = 0;
+                    printf("[INFO] Changed value of LwM2M resource /5000/0/1 is observed correctly \r\n");
+                } else {
+                    get_status = -1;
+                    printf("[ERROR] Wrong value observed in Pelion DM.\r\n");
+                }
+            } else {
+                printf("[ERROR] Wrong value reported from test.\r\n");
+                greentea_send_kv("fail_test", 0);
+            }
+        }
+
+        GREENTEA_TESTCASE_FINISH("LwM2M GET Test", (get_status == 0), (get_status != 0));
+
+        // PUT Test
+        GREENTEA_TESTCASE_START("LwM2M PUT Test");
+        int put_status;
         int current_res_value;
         int updated_res_value;
-
-        // Read orignal value of /5000/0/1
-        greentea_send_kv("device_lwm2m_get_test", "/5000/0/1");
-        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
-        TEST_ASSERT_EQUAL_STRING("test0", _value);
-        if (strcmp(_value, "test0") != 0) {
-            printf("[ERROR] Wrong value reported in Pelion DM.\r\n");
-            greentea_send_kv("fail_test", 0);
-        } else {
-            printf("[INFO] Original value of LwM2M resource /5000/0/1 is read correctly. \r\n");
-        }
-
-        // Update resource /5000/0/1 from client and observe value
-        greentea_send_kv("device_lwm2m_get_test", "/5000/0/1");
-        res_get_test->set_value("test1");
-        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
-        TEST_ASSERT_EQUAL_STRING("test1", _value);
-        if (strcmp(_value, "test1") != 0) {
-            printf("[ERROR] Wrong value observed from Pelion DM.\r\n");
-            greentea_send_kv("fail_test", 0);
-        } else {
-            printf("[INFO] Changed value of LwM2M resource /5000/0/1 is observed correctly. \r\n");
-        }
 
         // Observe resource /5000/0/2 from cloud, add +10, and confirm value is correct on client
         greentea_send_kv("device_lwm2m_put_test", "/5000/0/2");
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
 
-        // Get current value and updated value
-        updated_res_value = atoi(_value);
-        current_res_value = res_put_test->get_value_int();
+        if (strcmp(_key, "res_set") == 0) {
 
-        // Ensure current value and updated value are equal
-        TEST_ASSERT_EQUAL(updated_res_value, current_res_value);
-        if (updated_res_value != current_res_value) {
-            printf("[ERROR] Wrong value read from device after resource update.\r\n");
-            greentea_send_kv("fail_test", 0);
+            // Get updated value from host test.
+            updated_res_value = atoi(_value);
+            // Get current value from resource.
+            current_res_value = res_put_test->get_value_int();
+
+            if (updated_res_value == current_res_value) {
+                put_status = 0;
+                printf("[INFO] Value of resource /5000/0/2 successfully changed from the cloud using PUT. \r\n");
+            } else {
+                put_status = -1;
+                printf("[ERROR] Wrong value read from device after resource update.\r\n");
+            }
         } else {
-            printf("[INFO] Value of resource /5000/0/2 successfully changed from the cloud using PUT. \r\n");
+            printf("[ERROR] Wrong value reported from test.\r\n");
+            greentea_send_kv("fail_test", 0);
         }
+
+        GREENTEA_TESTCASE_FINISH("LwM2M PUT Test", (put_status == 0), (put_status != 0));
+
+        // POST test
+        GREENTEA_TESTCASE_START("LwM2M POST Test");
+        int post_status;
+
+        printf("[INFO] Executing POST on /5000/0/3 and waiting for callback function.");
+        greentea_send_kv("device_lwm2m_post_test", "/5000/0/3");
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+
+        if (strcmp(_key, "post_test_executed") == 0) {
+            int result = atoi(_value);
+            if (result == 0) {
+                post_status = 0;
+                printf("[INFO] Callback on resource /5000/0/3 executed successfully.");
+            } else {
+                post_status = -1;
+                printf("[ERROR] Callback on resource /5000/0/3 failed.");
+            }
+        } else {
+            printf("[ERROR] Wrong value reported from test.\r\n");
+            greentea_send_kv("fail_test", 0);
+        }
+
+        GREENTEA_TESTCASE_FINISH("LwM2M POST Test", (post_status == 0), (post_status != 0));
     }
 
     // Reset on first iteration of test.


### PR DESCRIPTION
This is the agreed upon approach with @screamerbg for TechCon release.

Separates out test cases within a single main.cpp test.
Tested and confirmed to work with: K64F and NUCLEO F429ZI.

Output:
```
mbedgt: test suite report:
+----------+---------------+-----------------------------------------------+--------+--------------------+-------------+
| target   | platform_name | test suite                                    | result | elapsed_time (sec) | copy_method |
+----------+---------------+-----------------------------------------------+--------+--------------------+-------------+
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | OK     | 119.06             | default     |
+----------+---------------+-----------------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+----------+---------------+-----------------------------------------------+-----------------------------------------+--------+--------+--------+-------------                                                    -------+
| target   | platform_name | test suite                                    | test case                               | passed | failed | result | elapsed_time                                                     (sec) |
+----------+---------------+-----------------------------------------------+-----------------------------------------+--------+--------+--------+-------------                                                    -------+
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | Connect to network                      | 1      | 0      | OK     | 11.01                                                                  |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | Consistent Identity                     | 1      | 0      | OK     | 0.07                                                                   |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | Device registration in Device Directory | 1      | 0      | OK     | 0.61                                                                   |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | Format storage                          | 1      | 0      | OK     | 15.45                                                                  |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | LwM2M GET Test                          | 1      | 0      | OK     | 1.33                                                                   |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | LwM2M POST Test                         | 1      | 0      | OK     | 0.49                                                                   |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | LwM2M PUT Test                          | 1      | 0      | OK     | 0.73                                                                   |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | Pelion Device Management Register       | 1      | 0      | OK     | 4.12                                                                   |
| K64F-ARM | K64F          | simple-mbed-cloud-client-tests-simple-connect | Simple Mbed Cloud Client Initialization | 1      | 0      | OK     | 2.6                                                                    |
+----------+---------------+-----------------------------------------------+-----------------------------------------+--------+--------+--------+-------------                                                    -------+
```