### PR TITLE
Simplify network setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ This library is a simpler interface to Pelion Cloud Client, making it trivial to
     int main() {
 
         /* Initialize connectivity */
-        <Network> net;
-        net.connect();
+        NetworkInterface *net = NetworkInterface::get_default_instance();
+        net->connect();
 
         /* Initialize storage */
         <Block device> sd(...);
         <Filesystem> fs("sd", &sd);
 
         /* Initialize Simple Pelion Client */
-        SimpleMbedCloudClient client(&net, &sd, &fs);
+        SimpleMbedCloudClient client(net, &sd, &fs);
         client.init();
 
         /* Create resource */

--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -42,23 +42,8 @@ void smcc_register(void) {
     printf("[INFO] Attempting to connect to network.\r\n");
 
     // Connection definition.
-#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t net_status = net->connect();
-#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI
-    WiFiInterface *net = WiFiInterface::get_default_instance();
-    nsapi_error_t net_status = net->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
-#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
-    CellularBase *net = CellularBase::get_default_instance();
-    net->set_sim_pin(MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN);
-    net->set_credentials(MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN, MBED_CONF_NSAPI_DEFAULT_CELLULAR_USERNAME, MBED_CONF_NSAPI_DEFAULT_CELLULAR_PASSWORD);
-    nsapi_error_t net_status = net->connect();
-#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
-    MeshInterface *net = MeshInterface::get_default_instance();
-    nsapi_error_t net_status = net->connect();
-#else
-    #error "Default network interface not defined"
-#endif
 
     GREENTEA_TESTCASE_FINISH("Connect to network", (net_status == 0), (net_status != 0));
 


### PR DESCRIPTION
Mbed OS 5.10 abstracts details on network interfaces, making applications easier to work multiple connectivities types.

This is a simplification of the tests to use the default network interface. Specific changes may need to come from `mbed_app.json` as already being done (e.g. WIFI SSID, PASS, etc).

@bridadan @dhwalters423 