### PR TITLE
Increase test timeout for slow networks

### DIFF
--- a/TESTS/simple/connect/main.cpp
+++ b/TESTS/simple/connect/main.cpp
@@ -384,7 +384,7 @@ int main(void) {
     Thread thread;
     thread.start(led_thread);
 
-    GREENTEA_SETUP(150, "sdk_host_tests");
+    GREENTEA_SETUP(210, "sdk_host_tests");
     spdmc_testsuite_connect();
 
     return 0;


### PR DESCRIPTION
This is required to let some platforms and connectivity to work, eg C030 + Cellular

@janjongboom @screamerbg 