### PR TITLE
Feature: Firmware Update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,18 @@ $ mbed dm init -d "<your company name in Pelion DM>" --model-name "<product mode
  1. Import an Simple Pelion DM Client application that contains the corresponding configuration in `mbed_app.json`. The application will include this Simple Pelion DM Client library.
 
     For examples of platform configuration, see the applications available in the [Quick-start](https://cloud.mbed.com/quick-start).
-   
- 2. Include the `mbed_cloud_dev_credentials.c` developer certificate in your application. For detailed instructions [see the documentation](https://cloud.mbed.com/docs/current/connecting/provisioning-development-devices.html#creating-and-downloading-a-developer-certificate).
 
- 3. Set a global `mbed config` variable `CLOUD_SDK_API_KEY` on the host machine valid for the account that your device will connect to. For example:
+ 2. Set a global `mbed config` variable `CLOUD_SDK_API_KEY` on the host machine valid for the account that your device will connect to. For example:
 
      ```mbed config -G CLOUD_SDK_API_KEY <API_KEY>```
 
      For instructions on how to generate an API key, please [see the documentation](https://cloud.mbed.com/docs/current/integrate-web-app/api-keys.html#generating-an-api-key).
 
-   
+ 3. Initialize your Pelion DM credentials (once per project):
+    ```mbed dm init -d "<your organization>" --model-name "<product model>" -q --force```
+
+    This will create your private/public key pair and also initialize various .c files with these credentials, so you can use Pelion DM connect and (firmware) update features.
+
  4. Remove the `main.cpp`application from the project, or ensure the content of the file is wrapped with `#ifndef MBED_TEST_MODE`.
  
  5. Compile the tests with the `MBED_TEST_MODE` compilation flag.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ This library is a simpler interface to Pelion DM Client, making it trivial to ex
 
 ## Testing
 
-Simple Pelion DM Client provides Greentea tests to test your porting efforts.
+Simple Pelion DM Client provides Greentea tests to test your porting efforts. Before running these tests, it's recommended that you run the `mbed dm init` command, which will install all needed credentials for both Connect and Update Pelion DM features. You can use the following command:
+```
+$ mbed dm init -d "<your company name in Pelion DM>" --model-name "<product model identifier>" -q --force
+```
+
 
 ### Test cases - Connect
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ $ mbed dm init -d "<your company name in Pelion DM>" --model-name "<product mode
 | `Pelion DM Bootstrap & Register` | Bootstraps the device and registers it for first time with Pelion Device Management. |
 | `Pelion DM Directory` | Verifies that a registered device appears in the Device Directory in Pelion Device Management. |
 | `Prepare Firmware` | Prepares the firmware on the host side and calls `mbed dm` to initiate Pelion Device Management update campaign. |
-| `Download Firmware` | Downloads the firmware onto the device, resets it and verifies that the firmware has been applied. |
+| `Download Firmware` | Downloads the firmware onto the device. |
+| `Apply Firmware` | Reset the device, verifies that the firmware has correct checksum, applies it and re-verifies the applied firmware checksum. |
 | `Pelion DM Re-register` | Re-registers the device with Pelion Device Management using the new firmware and previously bootstrapped credentials. |
 | `Consistent Identity` | Verifies that the device identity is preserved over firmware update and device reset, confirming that Root of Trust is stored in SOTP correctly. |
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Simple Pelion DM Client provides Greentea tests to test your porting efforts.
 | `Pelion DM Bootstrap & Register` | Bootstraps the device and registers it for first time with Pelion Device Management. |
 | `Pelion DM Directory` | Verifies that a registered device appears in the Device Directory in Pelion Device Management. |
 | `Pelion DM Re-register` | Resets the device and re-registers with Pelion Device Management with previously bootstrapped credentials. |
-| `Consistent Identity` | Confirms that the device identity is preserved over a device reset, confirming that Root of Trust is stored in SOTP correctly. |
+| `Consistent Identity` | Verifies that the device identity is preserved over device reset, confirming that Root of Trust is stored in SOTP correctly. |
 | `LwM2M GET Test` | Confirms that Pelion DM API client can perform a GET request on an LwM2M resource. |
 | `LwM2M SET Test` | Sets/changes value from the device and confirms that Pelion DM API client can observe the value changing. |
 | `LwM2M PUT Test` | Confirms that Pelion DM API client can perform a PUT request on an LwM2M resource by setting a new value. |
@@ -92,9 +92,9 @@ Simple Pelion DM Client provides Greentea tests to test your porting efforts.
 | `Pelion DM Bootstrap & Register` | Bootstraps the device and registers it for first time with Pelion Device Management. |
 | `Pelion DM Directory` | Verifies that a registered device appears in the Device Directory in Pelion Device Management. |
 | `Prepare Firmware` | Prepares the firmware on the host side and calls `mbed dm` to initiate Pelion Device Management update campaign. |
-| `Download Firmware` | Downloads the firmware onto the devices, resets it and verifies that the firmware has been applied. |
-| `Pelion DM Re-register` | Resets the device and re-registers with Pelion Device Management with previously bootstrapped credentials. |
-| `Consistent Identity` | Confirms that the device identity is preserved over a device reset, confirming that Root of Trust is stored in SOTP correctly. |
+| `Download Firmware` | Downloads the firmware onto the device, resets it and verifies that the firmware has been applied. |
+| `Pelion DM Re-register` | Re-registers the device with Pelion Device Management using the new firmware and previously bootstrapped credentials. |
+| `Consistent Identity` | Verifies that the device identity is preserved over firmware update and device reset, confirming that Root of Trust is stored in SOTP correctly. |
 
 ### Requirements
  Simple Pelion DM tests rely on the Python SDK to test the end to end solution.

--- a/README.md
+++ b/README.md
@@ -66,20 +66,35 @@ This library is a simpler interface to Pelion DM Client, making it trivial to ex
 
 Simple Pelion DM Client provides Greentea tests to test your porting efforts.
 
-### Test cases
+### Test cases - Connect
 
 | **Test case** | **Description** |
 | ------------- | ------------- |
 | `Connect to Network` | Tests the connection to the network via network interface. |
 | `Format Storage` | Tests that a successful storage format occurs and storage is configured correctly. |
 | `Simple MCC Initialization` | Verifies that SPDMC can be initialized with the given network, storage, and filesystem configuration. This is where the FCU and KCM configuration is written to storage and the Root of Trust is written to SOTP. |
-| `Pelion DM Register` | Confirms the device is registered to Pelion Device Management from using the Pelion DM REST API. |
+| `Pelion DM Bootstrap & Register` | Bootstraps the device and registers it for first time with Pelion Device Management. |
 | `Pelion DM Directory` | Verifies that a registered device appears in the Device Directory in Pelion Device Management. |
+| `Pelion DM Re-register` | Resets the device and re-registers with Pelion Device Management with previously bootstrapped credentials. |
 | `Consistent Identity` | Confirms that the device identity is preserved over a device reset, confirming that Root of Trust is stored in SOTP correctly. |
 | `LwM2M GET Test` | Confirms that Pelion DM API client can perform a GET request on an LwM2M resource. |
 | `LwM2M SET Test` | Sets/changes value from the device and confirms that Pelion DM API client can observe the value changing. |
 | `LwM2M PUT Test` | Confirms that Pelion DM API client can perform a PUT request on an LwM2M resource by setting a new value. |
 | `LwM2M POST Test` | Confirms that Pelion DM API client can execute a POST on an LwM2M resource and the callback function on the device is called. |
+
+### Test cases - Update
+
+| **Test case** | **Description** |
+| ------------- | ------------- |
+| `Connect to Network` | Tests the connection to the network via network interface. |
+| `Format Storage` | Tests that a successful storage format occurs and storage is configured correctly. |
+| `Simple MCC Initialization` | Verifies that SPDMC can be initialized with the given network, storage, and filesystem configuration. This is where the FCU and KCM configuration is written to storage and the Root of Trust is written to SOTP. |
+| `Pelion DM Bootstrap & Register` | Bootstraps the device and registers it for first time with Pelion Device Management. |
+| `Pelion DM Directory` | Verifies that a registered device appears in the Device Directory in Pelion Device Management. |
+| `Prepare Firmware` | Prepares the firmware on the host side and calls `mbed dm` to initiate Pelion Device Management update campaign. |
+| `Download Firmware` | Downloads the firmware onto the devices, resets it and verifies that the firmware has been applied. |
+| `Pelion DM Re-register` | Resets the device and re-registers with Pelion Device Management with previously bootstrapped credentials. |
+| `Consistent Identity` | Confirms that the device identity is preserved over a device reset, confirming that Root of Trust is stored in SOTP correctly. |
 
 ### Requirements
  Simple Pelion DM tests rely on the Python SDK to test the end to end solution.

--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -402,7 +402,7 @@ int main(void) {
 
     greentea_send_kv("device_booted", 1);
 
-    GREENTEA_SETUP(210, "sdk_host_tests");
+    GREENTEA_SETUP(240, "sdk_host_tests");
     spdmc_testsuite_connect();
 
     return 0;

--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -71,7 +71,8 @@ void spdmc_testsuite_connect(void) {
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Connect to Network");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Format Storage");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Simple PDMC Initialization");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Register");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Bootstrap & Reg.");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Re-register");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Directory");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Consistent Identity");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "LwM2M GET Test");
@@ -158,8 +159,11 @@ void spdmc_testsuite_connect(void) {
     client.on_registered(&registered);
 
     // Register to Pelion Device Management.
-    GREENTEA_TESTCASE_START("Pelion DM Register");
-
+    if (iteration == 0) {
+        GREENTEA_TESTCASE_START("Pelion DM Bootstrap & Reg.");
+    } else {
+        GREENTEA_TESTCASE_START("Pelion DM Re-register");
+    }
     client.register_and_connect();
 
     int timeout = 30000;
@@ -179,7 +183,11 @@ void spdmc_testsuite_connect(void) {
         client_status = -1;
         greentea_send_kv("test_failed", 0);
     }
-    GREENTEA_TESTCASE_FINISH("Pelion DM Register", (client_status == 0), (client_status != 0));
+    if (iteration == 0) {
+        GREENTEA_TESTCASE_FINISH("Pelion DM Bootstrap & Reg.", (client_status == 0), (client_status != 0));
+    } else {
+        GREENTEA_TESTCASE_FINISH("Pelion DM Re-register", (client_status == 0), (client_status != 0));
+    }
 
     if (iteration == 0) {
         //Start registration status test

--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -179,8 +179,8 @@ void spdmc_testsuite_connect(void) {
         wait_nb(100);
         logger("[INFO] Device successfully registered to Pelion DM.\r\n");
     } else {
-        logger("[ERROR] Device failed to register.\r\n");
         client_status = -1;
+        logger("[ERROR] Device failed to register.\r\n");
         greentea_send_kv("test_failed", 0);
     }
     if (iteration == 0) {
@@ -210,6 +210,7 @@ void spdmc_testsuite_connect(void) {
                 } else {
                     reg_status = -1;
                     logger("[ERROR] Device could not be verified as registered in Device Directory.\r\n");
+                    greentea_send_kv("test_failed", 0);
                 }
                 break;
             }
@@ -217,14 +218,16 @@ void spdmc_testsuite_connect(void) {
 
         GREENTEA_TESTCASE_FINISH("Pelion DM Directory", (reg_status == 0), (reg_status != 0));
 
-        logger("[INFO] Resetting device.\r\n");
-        greentea_send_kv("test_advance", 0);
-        while (1) {
-            greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+        if (reg_status == 0) {
+            logger("[INFO] Resetting device.\r\n");
+            greentea_send_kv("test_advance", 0);
+            while (1) {
+                greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
 
-            if (strcmp(_key, "reset") == 0) {
-                system_reset();
-                break;
+                if (strcmp(_key, "reset") == 0) {
+                    system_reset();
+                    break;
+                }
             }
         }
     } else {

--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -72,8 +72,8 @@ void spdmc_testsuite_connect(void) {
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Format Storage");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Simple PDMC Initialization");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Bootstrap & Reg.");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Re-register");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Directory");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Re-register");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Consistent Identity");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "LwM2M GET Test");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "LwM2M SET Test");

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -272,7 +272,7 @@ int main(void) {
 
     greentea_send_kv("device_booted", 1);
 
-    GREENTEA_SETUP(300, "sdk_host_tests");
+    GREENTEA_SETUP(15*60, "sdk_host_tests");
     spdmc_testsuite_connect();
 
     return 0;

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -3,7 +3,7 @@
 #include "simple-mbed-cloud-client.h"
 #include "greentea-client/test_env.h"
 
-uint32_t test_timeout = 15*60;
+uint32_t test_timeout = 30*60;
 
 // Heartbeat blinky (to indicate that the board is still alive)
 DigitalOut led1(LED1);

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -74,8 +74,8 @@ void spdmc_testsuite_connect(void) {
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Bootstrap & Reg.");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Re-register");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Directory");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Prepare firmware");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Download firmware");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Prepare Firmware");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Download Firmware");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Consistent Identity");
     }
 

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -161,8 +161,8 @@ void spdmc_testsuite_connect(void) {
         wait_nb(100);
         logger("[INFO] Device successfully registered to Pelion DM.\r\n");
     } else {
-        logger("[ERROR] Device failed to register.\r\n");
         client_status = -1;
+        logger("[ERROR] Device failed to register.\r\n");
         greentea_send_kv("test_failed", 0);
     }
     if (iteration == 0) {
@@ -192,6 +192,7 @@ void spdmc_testsuite_connect(void) {
                 } else {
                     reg_status = -1;
                     logger("[ERROR] Device could not be verified as registered in Device Directory.\r\n");
+                    greentea_send_kv("test_failed", 0);
                 }
                 break;
             }
@@ -199,27 +200,30 @@ void spdmc_testsuite_connect(void) {
 
         GREENTEA_TESTCASE_FINISH("Pelion DM Directory", (reg_status == 0), (reg_status != 0));
 
-        GREENTEA_TESTCASE_START("Prepare Firmware");
-        wait_nb(500);
-        int fw_status;
-        greentea_send_kv("firmware_prepare", 1);
-        while (1) {
-            greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
-            if (strcmp(_key, "firmware_sent") == 0) {
-                if (atoi(_value)) {
-                    fw_status = 0;
-                } else {
-                    fw_status = -1;
-                    logger("[ERROR] While preparing firmware.\r\n");
+        if (reg_status == 0) {
+            GREENTEA_TESTCASE_START("Prepare Firmware");
+            wait_nb(500);
+            int fw_status;
+            greentea_send_kv("firmware_prepare", 1);
+            while (1) {
+                greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+                if (strcmp(_key, "firmware_sent") == 0) {
+                    if (atoi(_value)) {
+                        fw_status = 0;
+                    } else {
+                        fw_status = -1;
+                        logger("[ERROR] While preparing firmware.\r\n");
+                    }
+                    break;
                 }
-                break;
             }
-        }
-        GREENTEA_TESTCASE_FINISH("Prepare Firmware", (fw_status == 0), (fw_status != 0));
+            GREENTEA_TESTCASE_FINISH("Prepare Firmware", (fw_status == 0), (fw_status != 0));
 
-        GREENTEA_TESTCASE_START("Download Firmware");
-        logger("[INFO] Update campaign has started.\r\n");
-        // The device should download firmware and reset at this stage
+            GREENTEA_TESTCASE_START("Download Firmware");
+            logger("[INFO] Update campaign has started.\r\n");
+            // The device should download firmware and reset at this stage
+        }
+
         while (1) {
             wait_nb(1000);
         }

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -28,14 +28,14 @@ import re
 DEFAULT_CYCLE_PERIOD = 1.0
 
 class SDKTests(BaseHostTest):
-    
     __result = None
     deviceApi = None
     connectApi = None
     deviceID = None
     iteration = None
     post_timeout = None
-    subproc = None
+    firmware_proc = None
+    firmware_sent = False
 
     def send_safe(self, key, value):
         #self.send_kv('dummy_start', 0)
@@ -45,145 +45,153 @@ class SDKTests(BaseHostTest):
         self.send_kv(key, value)
         self.send_kv(key, value)
         #self.send_kv('dummy_end', 1)
-    
-    def test_steps(self):
-        # Step 0 set up test
-        system_reset = yield
-        
-        # Step 1 device connected to Pelion should reset.
-        self.send_safe('reset', 0)
-        time.sleep(self.program_cycle_s)
+
+    def _callback_device_booted(self, key, value, timestamp): 
+        # This is used to let the device boot normally
         self.send_safe('__sync', 0)
-        self.iteration = self.iteration + 1
-        system_reset = yield   
-        
-        #Step 2, finish
-        yield True
-        
+
     def _callback_device_ready(self, key, value, timestamp):
         # Send device iteration number after a reset
         self.send_safe('iteration', self.iteration)
-    
+
     def _callback_test_advance(self, key, value, timestamp):
         # Advance test sequence
-        try: 
-            if self.test_steps_sequence.send(None):
-                self.notify_complete(True)
-        except (StopIteration, RuntimeError) as exc:
-            self.notify_complete(False)
-        
-    def _callback_device_api_registration(self, key, value, timestamp):
-        try:
-            #set value for later use
-            self.deviceID = value
-            
-            # Check if device is in Mbed Cloud Device Directory
-            device = self.deviceApi.get_device(value)
-            
-            # Send registraton status to device
-            self.send_safe("registration", 1 if device.state == "registered" else 0)
-        except:
-            # SDK throws an exception if the device is not found (unsuccessful registration) or times out
-            self.send_safe("registration", 0)
-            
-    def _callback_device_verification(self, key, value, timestamp):
-        # Send true if old DeviceID is the same as current device is
-        self.send_safe("verification", 1 if self.deviceID == value else 0)
-        
+        self.iteration = self.iteration + 1
+        self.send_safe('reset', 0)
+
     def _callback_test_failed(self, key, value, timestamp):
         # Test failed. End it.
         self.notify_complete(False)
-        
-    def _callback_device_lwm2m_get_verification(self, key, value, timestamp):
+
+    """
+    Device Register routines
+    """
+    def _callback_verify_registration(self, key, value, timestamp):
+        try:
+            #set value for later use
+            self.deviceID = value
+
+            # Check if device is in Mbed Cloud Device Directory
+            device = self.deviceApi.get_device(value)
+
+            # Send registraton status to device
+            self.send_safe("registered", 1 if device.state == "registered" else 0)
+        except:
+            # SDK throws an exception if the device is not found (unsuccessful registration) or times out
+            self.send_safe("registered", 0)
+
+    def _callback_verify_identity(self, key, value, timestamp):
+        # Send true if old DeviceID is the same as current device is
+        self.send_safe("verified", 1 if self.deviceID == value else 0)
+
+    """
+    Device Connect routines
+    """
+    def _callback_verify_lwm2m_get(self, key, value, timestamp):
         timeout = 0
 
         # Get resource value from device
         async_response = self.connectApi.get_resource_value_async(self.deviceID, value)
-        
+
         # Set a 30 second timeout here.
         while not async_response.is_done and timeout <= 300:
             time.sleep(0.1)
             timeout += 1
-        
+
         if async_response.is_done:
             # Send resource value back to device
             self.send_safe("get_value", async_response.value)
         else:
             # Request timed out.
             self.send_safe("timeout", 0)
-    
-    def _callback_device_lwm2m_set_verification(self, key, value, timestamp):
+
+    def _callback_verify_lwm2m_set(self, key, value, timestamp):
         timeout = 0
 
         # Get resource value from device
         async_response = self.connectApi.get_resource_value_async(self.deviceID, value)
-        
+
         # Set a 30 second timeout here.
         while not async_response.is_done and timeout <= 300:
             time.sleep(0.1)
             timeout += 1
-        
+
         if async_response.is_done:
             # Send resource value back to device
             self.send_safe("set_value", async_response.value)
         else:
             # Request timed out.
             self.send_safe("timeout", 0)
-    
-    def _callback_device_lwm2m_put_verification(self, key, value, timestamp):
+
+    def _callback_verify_lwm2m_put(self, key, value, timestamp):
         timeout = 0
-        
+
         # Get resource value from device and increment it
         resource_value = self.connectApi.get_resource_value_async(self.deviceID, value)
-        
+
         # Set a 30 second timeout here.
         while not resource_value.is_done and timeout <= 300:
             time.sleep(0.1)
             timeout += 1
-            
+
         if not resource_value.is_done:
             self.send_safe("timeout", 0)
             return
-        
+
         updated_value = int(resource_value.value) + 5
-        
+
         # Set new resource value from cloud
         async_response = self.connectApi.set_resource_value_async(self.deviceID, value, updated_value)
-        
+
         # Set a 30 second timeout here.
         while not async_response.is_done and timeout <= 300:
             time.sleep(0.1)
             timeout += 1
-            
+
         if not async_response.is_done:
             self.send_safe("timeout", 0)
         else:
             # Send new resource value to device for verification.
             self.send_safe("res_set", updated_value);
-        
-    def _callback_device_lwm2m_post_verification(self, key, value, timestamp):
+
+    def _callback_verify_lwm2m_post(self, key, value, timestamp):
         timeout = 0
-        
+
         # Execute POST function on device
         resource_value = self.connectApi.execute_resource_async(self.deviceID, value)
-        
+
         # Set a 30 second timeout here.
         while not resource_value.is_done and timeout <= 300:
             time.sleep(0.1)
             timeout += 1
-            
+
         if not resource_value.is_done:
             self.send_safe("timeout", 0)
             self.post_timeout = 1
-        
-    def _callback_device_lwm2m_post_verification_result(self, key, value, timestamp):
-        
+
+    def _callback_verify_lwm2m_post_result(self, key, value, timestamp):
+
         # Called from callback function on device, POST function working as expected.
         # If post_timeout is not none, the request took longer than 30 seconds, which is
         # a failure. Don't send this value.
         if not self.post_timeout:
             self.send_safe("post_test_executed", 0)
-    
+
+    """
+    Device Firmware update routines
+    """
+    def _callback_firmware_ready(self, key, value, timestamp):
+        if self.firmware_sent:
+            # Firmware was sent, but wasn't applied if this callback is called
+            if self.firmware_proc:
+                self.firmware_proc.kill()
+                self.firmware_proc = None
+            self.notify_complete(False)
+            return -1
+        else:
+            # Send device iteration number after a reset
+            self.send_safe('iteration', self.iteration)
+
     def _callback_firmware_prepare(self, key, value, timestamp):
         if not self.deviceID:
             self.logger.prn_err("ERROR: No DeviceID")
@@ -199,11 +207,14 @@ class SDKTests(BaseHostTest):
         self.logger.prn_inf('Found FW update image: "%s"' % update_image)
 
         try:
+            # Open the firmware update image as provided by the build system
             with open(update_image, 'rb') as f:
                 raw = f.read()
-            raw = re.sub(r'spdmc_ready_chk', r'firmware_update', raw)
+            # Modify the initial "device_ready" sequence into a different one 
+            # (matching the string length) as an indication that the firmware was changed/updated
+            #raw = re.sub(r'spdmc_ready_chk', r'firmware_update', raw)
 
-            # save it
+            # Save the firmware into a temp place. Manifest tool has issues handling very long paths even if -n is specified
             update_mod_image = re.sub(r'.*[\\/](.+)\.([a-z0-9]+)$', r'.\1_update_mod.\2.tmp', image)
             with open(update_mod_image, 'wb') as f:
                 f.write(raw)
@@ -213,52 +224,52 @@ class SDKTests(BaseHostTest):
             return -1
         self.logger.prn_inf('Modified FW update image: "%s"' % update_mod_image)
 
+        # Use non-blocking call, but remember the process, so we can kill it later
         try:
-            self.subproc = subprocess.Popen(["mbed", "dm", "update", "device", "-p", update_mod_image, "-D", self.deviceID], stderr=subprocess.STDOUT)
+            self.firmware_proc = subprocess.Popen(["mbed", "dm", "update", "device", "-p", update_mod_image, "-D", self.deviceID], stderr=subprocess.STDOUT)
         except Exception, e:
             self.logger.prn_err("ERROR: Unable to execute 'mbed dm' sub-command")
             return -1
 
-        self.send_safe('firmware_ready', 1)
-        self.logger.prn_inf("Firmware update campaign started. Check for download progress.")
-
+        # At this point the firmware should be on it's way to the device
+        self.firmware_sent = True
+        self.send_safe('firmware_sent', 1)
+        self.logger.prn_inf("Firmware sent and update campaign started. Check for download progress.")
 
     def _callback_firmware_update(self, key, value, timestamp):
         self.logger.prn_inf("Firmware successfully updated!")
-        if self.subproc:
-            self.subproc.kill()
-            self.subproc = None
+        if self.firmware_proc:
+            self.firmware_proc.kill()
+            self.firmware_proc = None
         self.iteration = self.iteration + 1
         self.send_safe('iteration', self.iteration)
 
-    def _callback_booted(self, key, value, timestamp):
-        self.send_safe('__sync', 0)
-
-
     def setup(self):
-        #Start at iteration 0
-        self.iteration = 0
-        
-        # Register callbacks from GT tests
-        self.register_callback('device_api_registration', self._callback_device_api_registration)
+        # Generic test routines
+        self.register_callback('device_booted', self._callback_device_booted)
         self.register_callback('device_ready', self._callback_device_ready)
-        self.register_callback('spdmc_ready_chk', self._callback_device_ready)
         self.register_callback('test_advance', self._callback_test_advance)
         self.register_callback('test_failed', self._callback_test_failed)
-        self.register_callback('device_verification', self._callback_device_verification)
-        self.register_callback('device_lwm2m_get_test', self._callback_device_lwm2m_get_verification)
-        self.register_callback('device_lwm2m_set_test', self._callback_device_lwm2m_set_verification)
-        self.register_callback('device_lwm2m_put_test', self._callback_device_lwm2m_put_verification)
-        self.register_callback('device_lwm2m_post_test', self._callback_device_lwm2m_post_verification)
-        self.register_callback('device_lwm2m_post_test_result', self._callback_device_lwm2m_post_verification_result)
+
+        # Callbacks from device registration tests
+        self.register_callback('verify_registration', self._callback_verify_registration)
+        self.register_callback('verify_identity', self._callback_verify_identity)
+
+        # Callbacks from LWM2M tests
+        self.register_callback('verify_lwm2m_get_test', self._callback_verify_lwm2m_get)
+        self.register_callback('verify_lwm2m_set_test', self._callback_verify_lwm2m_set)
+        self.register_callback('verify_lwm2m_put_test', self._callback_verify_lwm2m_put)
+        self.register_callback('verify_lwm2m_post_test', self._callback_verify_lwm2m_post)
+        self.register_callback('verify_lwm2m_post_test_result', self._callback_verify_lwm2m_post_result)
+
+        # Callbacks from FW update tests
+        self.register_callback('spdmc_ready_chk', self._callback_firmware_ready)
         self.register_callback('firmware_prepare', self._callback_firmware_prepare)
         self.register_callback('firmware_update', self._callback_firmware_update)
-        self.register_callback('booted', self._callback_booted)
 
         # Setup API config
         try:
-            result = subprocess.check_output(["mbed", "config", "--list"], \
-                                            stderr=subprocess.STDOUT)
+            result = subprocess.check_output(["mbed", "config", "--list"], stderr=subprocess.STDOUT)
         except Exception, e:
             self.logger.prn_err("ERROR: CLOUD_SDK_API_KEY global config is not set: " + str(e))
             return -1
@@ -274,11 +285,13 @@ class SDKTests(BaseHostTest):
         self.logger.prn_inf("CLOUD_SDK_API_KEY: " + api_key_val)
 
         api_config = {"api_key" : api_key_val, "host" : "https://api.us-east-1.mbedcloud.com"}
-        
+
+        self.iteration = 0
+
         # Instantiate Device and Connect API
         self.deviceApi = DeviceDirectoryAPI(api_config)
         self.connectApi = ConnectAPI(api_config)
-        
+
     def result(self):
         return self.__result
 
@@ -286,14 +299,8 @@ class SDKTests(BaseHostTest):
         # Delete device from directory so as not to hit device allocation quota.
         if self.deviceID:
             self.deviceApi.delete_device(self.deviceID)
-            
         pass
-    
+
     def __init__(self):
         super(SDKTests, self).__init__()
-        cycle_s = self.get_config_item('program_cycle_s')
-        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
-        
-        self.test_steps_sequence = self.test_steps()
-        self.test_steps_sequence.send(None)
         self.logger = HtrunLogger('TEST')

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -184,8 +184,9 @@ class SDKTests(BaseHostTest):
     """
     def firmware_campaign_cleanup(self):
         if self.firmware_proc:
-            os.kill(self.firmware_proc.pid, signal.CTRL_C_EVENT)
-            os.kill(self.firmware_proc.pid, signal.CTRL_BREAK_EVENT)
+            if os.name == 'nt':
+                os.kill(self.firmware_proc.pid, signal.CTRL_C_EVENT)
+                os.kill(self.firmware_proc.pid, signal.CTRL_BREAK_EVENT)
             self.firmware_proc.terminate()
             outs, errs = self.firmware_proc.communicate()
             self.logger.prn_inf('Firmware campaign process killed: PID %s' % self.firmware_proc.pid)

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -190,9 +190,14 @@ class SDKTests(BaseHostTest):
             outs, errs = self.firmware_proc.communicate()
             self.logger.prn_inf('Firmware campaign process killed: PID %s' % self.firmware_proc.pid)
             self.firmware_proc = None
-        if self.firmware_file:
-            os.remove(self.firmware_file)
-            self.firmware_file = None
+
+            try:
+                time.sleep(1) # let the manifest-tool sub-process die gracefully
+                if self.firmware_file:
+                    os.remove(self.firmware_file)
+                    self.firmware_file = None
+            except Exception, e:
+                pass
 
     def _callback_firmware_ready(self, key, value, timestamp):
         if self.firmware_sent:
@@ -321,6 +326,8 @@ class SDKTests(BaseHostTest):
         # Delete device from directory so as not to hit device allocation quota.
         if self.deviceID:
             self.deviceApi.delete_device(self.deviceID)
+        self.firmware_campaign_cleanup()
+
         pass
 
     def __init__(self):

--- a/update_ui_example.cpp
+++ b/update_ui_example.cpp
@@ -32,7 +32,7 @@ void update_ui_set_cloud_client(MbedCloudClient* client)
     _client = client;
 }
 
-void update_authorize(int32_t request)
+void __attribute__((weak)) update_authorize(int32_t request)
 {
     switch (request)
     {
@@ -72,7 +72,7 @@ void update_authorize(int32_t request)
 #endif
 #endif
 
-void update_progress(uint32_t progress, uint32_t total)
+void __attribute__((weak)) update_progress(uint32_t progress, uint32_t total)
 {
     uint8_t percent = progress * 100 / total;
 


### PR DESCRIPTION
This PR introduces Firmware Update tests for Pelion DM, including documentation about the test cases and prerequisites.

### Test cases - Update

| **Test case** | **Description** |
| ------------- | ------------- |
| `Connect to Network` | Tests the connection to the network via network interface. |
| `Format Storage` | Tests that a successful storage format occurs and storage is configured correctly. |
| `Simple MCC Initialization` | Verifies that SPDMC can be initialized with the given network, storage, and filesystem configuration. This is where the FCU and KCM configuration is written to storage and the Root of Trust is written to SOTP. |
| `Pelion DM Bootstrap & Register` | Bootstraps the device and registers it for first time with Pelion Device Management. |
| `Pelion DM Directory` | Verifies that a registered device appears in the Device Directory in Pelion Device Management. |
| `Prepare Firmware` | Prepares the firmware on the host side and calls `mbed dm` to initiate Pelion Device Management update campaign. |
| `Download Firmware` | Downloads the firmware onto the device, resets it and verifies that the firmware has been applied. |
| `Pelion DM Re-register` | Re-registers the device with Pelion Device Management using the new firmware and previously bootstrapped credentials. |
| `Consistent Identity` | Verifies that the device identity is preserved over firmware update and device reset, confirming that Root of Trust is stored in SOTP correctly. |

This PR also polishes some of the Connect tests and device reset handling behavior.

Attached are example test logs:
* [smcc_fwupdate_success.txt](https://github.com/ARMmbed/simple-mbed-cloud-client/files/2591883/smcc_fwupdate_success.txt)
* [smcc_fwupdate_failed.txt](https://github.com/ARMmbed/simple-mbed-cloud-client/files/2591884/smcc_fwupdate_failed.txt)
