### PR TITLE
Enlarge timeout of client register

### DIFF
--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -175,7 +175,7 @@ void spdmc_testsuite_connect(void) {
     }
     client.register_and_connect();
 
-    int timeout = 30000;
+    int timeout = 60000;
     while (timeout && !client.is_client_registered()) {
         timeout--;
         wait_ms(1);

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -211,7 +211,7 @@ void spdmc_testsuite_update(void) {
     }
     client.register_and_connect();
 
-    int timeout = 30000;
+    int timeout = 60000;
     while (timeout && !client.is_client_registered()) {
         timeout--;
         wait_ms(1);


### PR DESCRIPTION
According to K64F & NUMAKER_IOT_M487 platform through WiFi connection, default time out 30 seconds is not enough, so suggest to adjust as 60 seconds.
Details of test log are attached for your reference.

[k64f_smcc_armcc.txt](https://github.com/ARMmbed/simple-mbed-cloud-client/files/2619412/k64f_smcc_armcc.txt)

[Uploading m487_smcc_armcc.txt…]()
