### PR TITLE
Device Management tests improvements

### DIFF
--- a/TESTS/basic/net-single/main.cpp
+++ b/TESTS/basic/net-single/main.cpp
@@ -106,9 +106,11 @@ utest::v1::status_t greentea_setup(const size_t number_of_cases) {
 Case cases[] = {
     Case(TEST_NETWORK_TYPE " network setup", setup_network),
     Case(TEST_NETWORK_TYPE "   128 buffer", download_128),
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE != CELLULAR
     Case(TEST_NETWORK_TYPE "   256 buffer", download_256),
     Case(TEST_NETWORK_TYPE "  1024 buffer", download_1k),
     Case(TEST_NETWORK_TYPE "  4096 buffer", download_4k),
+#endif
 };
 
 Specification specification(greentea_setup, cases);

--- a/TESTS/basic/net-threaded/main.cpp
+++ b/TESTS/basic/net-threaded/main.cpp
@@ -142,7 +142,9 @@ utest::v1::status_t greentea_setup(const size_t number_of_cases) {
 Case cases[] = {
     Case(TEST_NETWORK_TYPE " network setup", setup_network),
     Case(TEST_NETWORK_TYPE " 1 thread", download_1_thread),
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE != CELLULAR
     Case(TEST_NETWORK_TYPE " 2 threads", download_2_threads),
+#endif
     //Case(TEST_NETWORK_TYPE " 3 threads", download_3_threads),
     // 4 threads may fail due to http host limits
     //Case(TEST_NETWORK_TYPE " 4 threads", download_4_threads),

--- a/TESTS/basic/stress-net-fs/main.cpp
+++ b/TESTS/basic/stress-net-fs/main.cpp
@@ -179,8 +179,10 @@ utest::v1::status_t greentea_setup(const size_t number_of_cases) {
 Case cases[] = {
     Case(TEST_NETWORK_TYPE " network setup", setup_network),
     Case(TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE " format", test_format),
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE != CELLULAR
     Case(TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE "+" TEST_NETWORK_TYPE " 1 thread, dl, file seq.", stress_1_thread),
     Case(TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE "+" TEST_NETWORK_TYPE " 2 threads, dl, 1kb", stress_2_threads),
+#endif
     Case(TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE "+" TEST_NETWORK_TYPE " 3 threads, dl, 256b, 1kb", stress_3_threads),
     //Case(TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE "+" TEST_NETWORK_TYPE " 4 threads, dl, 256b, 256b, 256b", stress_4_threads),
 };

--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -37,10 +37,7 @@ void led_thread() {
 RawSerial pc(USBTX, USBRX);
 
 void wait_nb(uint16_t ms) {
-    while (ms > 0) {
-        ms--;
-        wait_ms(1);
-    }
+    wait_ms(ms);
 }
 void test_failed() {
     greentea_send_kv("test_failed", 1);
@@ -70,6 +67,7 @@ void post_test_callback(MbedCloudClientResource *resource, const uint8_t *buffer
 }
 
 void spdmc_testsuite_connect(void) {
+    int i = 0;
     int iteration = 0;
     char _key[20] = { };
     char _value[128] = { };
@@ -211,10 +209,9 @@ void spdmc_testsuite_connect(void) {
     client.on_registered(&registered);
     client.register_and_connect();
 
-    int timeout = 60000;
-    while (timeout && !client.is_client_registered()) {
-        timeout--;
-        wait_ms(10);
+    i = 600; // wait 60 seconds
+    while (i-- > 0 && !client.is_client_registered()) {
+        wait_ms(100);
     }
 
     // Get registration status.
@@ -239,8 +236,11 @@ void spdmc_testsuite_connect(void) {
         GREENTEA_TESTCASE_START("Pelion DM Directory");
         int reg_status;
 
-        logger("[INFO] Wait 5 seconds for Device Directory to update after initial registration.\r\n");
-        wait_nb(5000);
+        logger("[INFO] Wait up to 10 seconds for Device Directory to update after initial registration.\r\n");
+        i = 100;
+        while (i-- > 0 and !endpointInfo) {
+            wait(100);
+        }
 
         // Start host tests with device id
         logger("[INFO] Starting Pelion DM verification using Python SDK...\r\n");
@@ -280,8 +280,11 @@ void spdmc_testsuite_connect(void) {
         GREENTEA_TESTCASE_START("Post-reset Identity");
         int identity_status;
 
-        logger("[INFO] Wait 2 seconds for Device Directory to update after reboot.\r\n");
-        wait_nb(2000);
+        logger("[INFO] Wait up to 5 seconds for Device Directory to update after reboot.\r\n");
+        i = 50;
+        while (i-- > 0 and !endpointInfo) {
+            wait(100);
+        }
 
         // Wait for Host Test to verify consistent device ID (blocking here)
         logger("[INFO] Verifying consistent Device ID...\r\n");
@@ -306,8 +309,8 @@ void spdmc_testsuite_connect(void) {
         // LwM2M tests
         logger("[INFO] Beginning LwM2M resource tests.\r\n");
 
+        wait_nb(1000);
 
-        wait_nb(500);
         // ---------------------------------------------
         // GET test
         GREENTEA_TESTCASE_START("Resource LwM2M GET");
@@ -334,8 +337,8 @@ void spdmc_testsuite_connect(void) {
         }
         GREENTEA_TESTCASE_FINISH("Resource LwM2M GET", (get_status == 0), (get_status != 0));
 
-
         wait_nb(500);
+
         // ---------------------------------------------
         // SET test
         GREENTEA_TESTCASE_START("Resource LwM2M SET");
@@ -364,8 +367,8 @@ void spdmc_testsuite_connect(void) {
         }
         GREENTEA_TESTCASE_FINISH("Resource LwM2M SET", (set_status == 0), (set_status != 0));
 
-
         wait_nb(500);
+
         // ---------------------------------------------
         // PUT Test
         GREENTEA_TESTCASE_START("Resource LwM2M PUT");
@@ -401,8 +404,8 @@ void spdmc_testsuite_connect(void) {
 
         GREENTEA_TESTCASE_FINISH("Resource LwM2M PUT", (put_status == 0), (put_status != 0));
 
-
         wait_nb(500);
+
         // ---------------------------------------------
         // POST test
         GREENTEA_TESTCASE_START("Resource LwM2M POST");
@@ -435,7 +438,7 @@ void spdmc_testsuite_connect(void) {
         GREENTEA_TESTSUITE_RESULT((get_status == 0) && (set_status == 0) && (put_status == 0) && (post_status == 0));
 
         while (1) {
-            wait(1);
+            wait(100);
         }
     }
 }

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -41,9 +41,6 @@ RawSerial pc(USBTX, USBRX);
 void wait_nb(uint16_t ms) {
     wait_ms(ms);
 }
-void test_failed() {
-    greentea_send_kv("test_failed", 1);
-}
 
 void logger(const char* message, const char* decor) {
     wait_nb(10);
@@ -54,6 +51,19 @@ void logger(const char* message) {
     wait_nb(10);
     pc.printf(message);
     wait_nb(10);
+}
+void test_failed() {
+    greentea_send_kv("test_failed", 1);
+}
+void test_case_start(const char *name, size_t index) {
+    wait_nb(10);
+    pc.printf("\r\n>>> Running case #%u: '%s'...\n", index, name);
+    GREENTEA_TESTCASE_START(name);
+}
+void test_case_finish(const char *name, size_t passed, size_t failed) {
+    GREENTEA_TESTCASE_FINISH(name, passed, failed);
+    wait_nb(10);
+    pc.printf(">>> '%s': %u passed, %u failed\r\n", name, passed, failed);
 }
 
 uint32_t dl_last_rpercent = 0;
@@ -87,8 +97,8 @@ void update_progress(uint32_t progress, uint32_t total) {
         dl_started = false;
         pc.printf("[INFO] Firmware download completed. %.2fKB in %.2f seconds (%.2fKB/s)\r\n",
             float(total) / 1024, dl_timer.read(), float(total) / dl_timer.read() / 1024);
-        GREENTEA_TESTCASE_FINISH("Firmware Download", true, false);
-        GREENTEA_TESTCASE_START("Firmware Update");
+        test_case_finish("Pelion Firmware Download", 1, 0);
+        test_case_start("Pelion Firmware Update", 9);
     }
 }
 
@@ -122,19 +132,19 @@ void spdmc_testsuite_update(void) {
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Connect to " TEST_NETWORK_TYPE);
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Format " TEST_FILESYSTEM_TYPE);
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Initialize Simple PDMC");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Bootstrap & Reg.");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Directory");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Firmware Prepare");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Firmware Download");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Firmware Update");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion DM Re-register");
-        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Post-update Identity");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion Bootstrap & Reg.");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion Directory");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion Firmware Prepare");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion Firmware Download");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion Firmware Update");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Pelion Re-register");
         greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Post-update Erase");
+        greentea_send_kv(GREENTEA_TEST_ENV_TESTCASE_NAME, "Post-update Identity");
     } else {
-        GREENTEA_TESTCASE_FINISH("Firmware Update", true, false);
+        test_case_finish("Pelion Firmware Update", true, false);
     }
 
-    GREENTEA_TESTCASE_START("Initialize " TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE);
+    test_case_start("Initialize " TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE, 1);
     logger("[INFO] Attempting to initialize storage.\r\n");
 
     // Default storage definition.
@@ -146,20 +156,21 @@ void spdmc_testsuite_update(void) {
     LittleFileSystem fs("fs", &sd);
 #endif
 
-    GREENTEA_TESTCASE_FINISH("Initialize " TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE, 1, 0);
+    test_case_finish("Initialize " TEST_BLOCK_DEVICE_TYPE "+" TEST_FILESYSTEM_TYPE, iteration + 1, 0);
 
+    // Corrupt the image after successful firmware update to ensure that the bootloader won't try to apply it for other test runs
     if (iteration) {
 #if defined(MBED_CONF_UPDATE_CLIENT_STORAGE_ADDRESS) && defined(MBED_CONF_UPDATE_CLIENT_STORAGE_SIZE)
-        GREENTEA_TESTCASE_START("Post-update Erase");
+        test_case_start("Post-update Erase", 11);
 
         uint32_t garbage[8];
         int erase_status = bd->program(garbage, MBED_CONF_UPDATE_CLIENT_STORAGE_ADDRESS, bd->get_program_size());
-        GREENTEA_TESTCASE_FINISH("Post-update Erase", (erase_status == 0), (erase_status != 0));
+        test_case_finish("Post-update Erase", (erase_status == 0), (erase_status != 0));
 #endif
     }
 
     // Start network connection test.
-    GREENTEA_TESTCASE_START("Connect to " TEST_NETWORK_TYPE);
+    test_case_start("Connect to " TEST_NETWORK_TYPE, 2);
     logger("[INFO] Attempting to connect to network.\r\n");
 
     // Connection definition.
@@ -182,10 +193,10 @@ void spdmc_testsuite_update(void) {
         logger("[INFO] Connected to network successfully. IP address: %s\n", net->get_ip_address());
     }
 
-    GREENTEA_TESTCASE_FINISH("Connect to " TEST_NETWORK_TYPE, (net_status == 0), (net_status != 0));
+    test_case_finish("Connect to " TEST_NETWORK_TYPE, iteration + (net_status == 0), (net_status != 0));
 
     if (iteration == 0) {
-        GREENTEA_TESTCASE_START("Format " TEST_FILESYSTEM_TYPE);
+        test_case_start("Format " TEST_FILESYSTEM_TYPE, 3);
         logger("[INFO] Resetting storage to a clean state for test.\n");
 
         int storage_status = fs.reformat(&sd);
@@ -207,11 +218,11 @@ void spdmc_testsuite_update(void) {
             test_failed();
         }
 
-        GREENTEA_TESTCASE_FINISH("Format " TEST_FILESYSTEM_TYPE, (storage_status == 0), (storage_status != 0));
+        test_case_finish("Format " TEST_FILESYSTEM_TYPE, (storage_status == 0), (storage_status != 0));
     }
 
     // SimpleMbedCloudClient initialization must be successful.
-    GREENTEA_TESTCASE_START("Initialize Simple PDMC");
+    test_case_start("Initialize Simple PDMC", 4);
 
     SimpleMbedCloudClient client(net, bd, &fs);
     int client_status = client.init();
@@ -225,7 +236,7 @@ void spdmc_testsuite_update(void) {
         test_failed();
     }
 
-    GREENTEA_TESTCASE_FINISH("Initialize Simple PDMC", (client_status == 0), (client_status != 0));
+    test_case_finish("Initialize Simple PDMC", iteration + (client_status == 0), (client_status != 0));
 
     //Create LwM2M resources
     MbedCloudClientResource *res_get_test;
@@ -236,9 +247,9 @@ void spdmc_testsuite_update(void) {
 
     // Register to Pelion Device Management.
     if (iteration == 0) {
-        GREENTEA_TESTCASE_START("Pelion DM Bootstrap & Reg.");
+        test_case_start("Pelion Bootstrap & Reg.", 5);
     } else {
-        GREENTEA_TESTCASE_START("Pelion DM Re-register");
+        test_case_start("Pelion Re-register", 10);
     }
     // Set client callback to report endpoint name.
     client.on_registered(&registered);
@@ -261,14 +272,14 @@ void spdmc_testsuite_update(void) {
         test_failed();
     }
     if (iteration == 0) {
-        GREENTEA_TESTCASE_FINISH("Pelion DM Bootstrap & Reg.", (client_status == 0), (client_status != 0));
+        test_case_finish("Pelion Bootstrap & Reg.", (client_status == 0), (client_status != 0));
     } else {
-        GREENTEA_TESTCASE_FINISH("Pelion DM Re-register", (client_status == 0), (client_status != 0));
+        test_case_finish("Pelion Re-register", (client_status == 0), (client_status != 0));
     }
 
     if (iteration == 0) {
         //Start registration status test
-        GREENTEA_TESTCASE_START("Pelion DM Directory");
+        test_case_start("Pelion Directory", 6);
         int reg_status;
 
         logger("[INFO] Wait up to 10 seconds for Device Directory to update after initial registration.\r\n");
@@ -278,7 +289,7 @@ void spdmc_testsuite_update(void) {
         }
 
         // Start host tests with device id
-        logger("[INFO] Starting Pelion DM verification using Python SDK...\r\n");
+        logger("[INFO] Starting Pelion verification using Python SDK...\r\n");
         greentea_send_kv("verify_registration", endpointInfo->internal_endpoint_name.c_str());
         while (1) {
             greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
@@ -296,10 +307,10 @@ void spdmc_testsuite_update(void) {
             }
         }
 
-        GREENTEA_TESTCASE_FINISH("Pelion DM Directory", (reg_status == 0), (reg_status != 0));
+        test_case_finish("Pelion Directory", (reg_status == 0), (reg_status != 0));
 
         if (reg_status == 0) {
-            GREENTEA_TESTCASE_START("Firmware Prepare");
+            test_case_start("Pelion Firmware Prepare", 7);
             wait_nb(500);
             int fw_status;
             greentea_send_kv("firmware_prepare", 1);
@@ -315,9 +326,9 @@ void spdmc_testsuite_update(void) {
                     break;
                 }
             }
-            GREENTEA_TESTCASE_FINISH("Firmware Prepare", (fw_status == 0), (fw_status != 0));
+            test_case_finish("Pelion Firmware Prepare", (fw_status == 0), (fw_status != 0));
 
-            GREENTEA_TESTCASE_START("Firmware Download");
+            test_case_start("Pelion Firmware Download", 8);
             logger("[INFO] Update campaign has started.\r\n");
             // The device should download firmware and reset at this stage
         }
@@ -327,7 +338,7 @@ void spdmc_testsuite_update(void) {
         }
     } else {
         //Start consistent identity test.
-        GREENTEA_TESTCASE_START("Post-update Identity");
+        test_case_start("Post-update Identity", 12);
         int identity_status;
 
         logger("[INFO] Wait up to 5 seconds for Device Directory to update after reboot.\r\n");
@@ -354,7 +365,7 @@ void spdmc_testsuite_update(void) {
             }
         }
 
-        GREENTEA_TESTCASE_FINISH("Post-update Identity", (identity_status == 0), (identity_status != 0));
+        test_case_finish("Post-update Identity", (identity_status == 0), (identity_status != 0));
 
         GREENTEA_TESTSUITE_RESULT(identity_status == 0);
 

--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -33,11 +33,12 @@ class SDKTests(BaseHostTest):
     deviceApi = None
     connectApi = None
     deviceID = None
-    iteration = None
     post_timeout = None
     firmware_proc = None
     firmware_sent = False
     firmware_file = None
+    iteration = 0
+    boot_cycles = 0
 
     def send_safe(self, key, value):
         #self.send_kv('dummy_start', 0)
@@ -54,7 +55,10 @@ class SDKTests(BaseHostTest):
 
     def _callback_device_ready(self, key, value, timestamp):
         # Send device iteration number after a reset
-        self.send_safe('iteration', self.iteration)
+        self.boot_cycles += 1
+        # Prevent boot loop due to Mbed OS crash
+        if self.boot_cycles <= 5:
+            self.send_safe('iteration', self.iteration)
 
     def _callback_test_advance(self, key, value, timestamp):
         # Advance test sequence
@@ -323,6 +327,7 @@ class SDKTests(BaseHostTest):
         api_config = {"api_key" : api_key_val, "host" : "https://api.us-east-1.mbedcloud.com"}
 
         self.iteration = 0
+        self.boot_cycles = 0
 
         # Instantiate Device and Connect API
         self.deviceApi = DeviceDirectoryAPI(api_config)


### PR DESCRIPTION
This PR aims to improve the following aspects of Device Management tests for SPDMC:
* Use `wait_ms()` instead of `while()` loop, which was previously used to prevent strange behavior with some Targets in TICKLESS mode.
* Speed-up Pelion DM registration and PDM device directory test cases by querying on every 100ms instead of previously hardcoded 5 seconds wait. Also increase the timeout for these test cases to 10 seconds.
* Prevent boot loop due to Mbed OS crash by limiting the times the host test python script will respond (currently up to 5 `{{device_ready}}` messages)
* Improve the output of both Connect and Update test suites for better readability when using verbose mode `mbed test ... -v`. See example 1 below.
* Correctly report the number of successful test runs for a routine if ran more than once 9, e.g. "Initialize BD+DS", "Connect to Network" etc occur more than once in a test run. See example 2.
* Reduce the scope of networking tests over Cellular due to tests timing out caused by low Cellular speeds. The tests will be restored once dynamic test timeouts are relased with greentea/htrun. PR for the dynamic test timeout feature - https://github.com/ARMmbed/htrun/pull/228


**Example 1**
```
[1543713891.05][CONN][RXD] >>> Running case #1: 'Initialize QSPIF+LFS'...
[1543713891.05][CONN][INF] found KV pair in stream: {{__testcase_name;Post-update Identity}}, queued...
[1543713891.05][SERI][TXD] {{iteration;0}}
[1543713891.06][CONN][INF] found KV pair in stream: {{__testcase_start;Initialize QSPIF+LFS}}, queued...
[1543713891.08][CONN][RXD] [INFO] Attempting to initialize storage.
[1543713891.11][CONN][RXD] >>> 'Initialize QSPIF+LFS': 1 passed, 0 failed
[1543713891.11][CONN][INF] found KV pair in stream: {{__testcase_finish;Initialize QSPIF+LFS;1;0}}, queued...
[1543713891.12][CONN][RXD]
[1543713891.12][CONN][RXD] >>> Running case #2: 'Connect to WiFi'...
[1543713891.14][CONN][RXD] [INFO] Attempting to connect to network.
[1543713891.14][CONN][INF] found KV pair in stream: {{__testcase_start;Connect to WiFi}}, queued...
[1543713894.89][CONN][RXD] [INFO] Connected to network successfully. IP address: 192.168.101.64
[1543713894.90][CONN][INF] found KV pair in stream: {{__testcase_finish;Connect to WiFi;1;0}}, queued...
[1543713894.92][CONN][RXD] >>> 'Connect to WiFi': 1 passed, 0 failed
[1543713894.93][CONN][RXD]
[1543713894.93][CONN][RXD] >>> Running case #3: 'Format LFS'...
[1543713894.93][CONN][INF] found KV pair in stream: {{__testcase_start;Format LFS}}, queued...
[1543713894.95][CONN][RXD] [INFO] Resetting storage to a clean state for test.
[1543713895.15][CONN][RXD] [INFO] Storage format successful.
[1543713895.18][CONN][RXD] >>> 'Format LFS': 1 passed, 0 failed
[1543713895.18][CONN][RXD]
[1543713895.18][CONN][INF] found KV pair in stream: {{__testcase_finish;Format LFS;1;0}}, queued...
[1543713895.20][CONN][RXD] >>> Running case #4: 'Initialize Simple PDMC'...
[1543713895.20][CONN][INF] found KV pair in stream: {{__testcase_start;Initialize Simple PDMC}}, queued...
[1543713908.20][CONN][RXD] [INFO] Simple PDMC initialization successful.
[1543713908.22][CONN][INF] found KV pair in stream: {{__testcase_finish;Initialize Simple PDMC;1;0}}, queued...
[1543713908.23][CONN][RXD] >>> 'Initialize Simple PDMC': 1 passed, 0 failed
```

**Example 2**
```
[1543714029.13][CONN][RXD] >>> Running case #11: 'Post-update Erase'...
[1543714029.13][CONN][RXD] >>> 'Post-update Erase': 1 passed, 0 failed
[1543714029.13][CONN][INF] found KV pair in stream: {{__testcase_start;Post-update Erase}}, queued...
[1543714029.13][CONN][INF] found KV pair in stream: {{__testcase_finish;Post-update Erase;1;0}}, queued...
[1543714029.15][CONN][RXD]
[1543714029.15][CONN][RXD] >>> Running case #2: 'Connect to WiFi'...
[1543714029.15][CONN][INF] found KV pair in stream: {{__testcase_start;Connect to WiFi}}, queued...
[1543714029.16][CONN][RXD] [INFO] Attempting to connect to network.
[1543714032.90][CONN][RXD] [INFO] Connected to network successfully. IP address: 192.168.101.64
[1543714032.90][CONN][INF] found KV pair in stream: {{__testcase_finish;Connect to WiFi;2;0}}, queued...
[1543714032.91][CONN][RXD] >>> 'Connect to WiFi': 2 passed, 0 failed
[1543714032.93][CONN][RXD]
[1543714032.93][CONN][RXD] >>> Running case #4: 'Initialize Simple PDMC'...
[1543714032.93][CONN][INF] found KV pair in stream: {{__testcase_start;Initialize Simple PDMC}}, queued...
[1543714035.71][CONN][RXD] [INFO] Simple PDMC initialization successful.
[1543714035.73][CONN][INF] found KV pair in stream: {{__testcase_finish;Initialize Simple PDMC;2;0}}, queued...
[1543714035.74][CONN][RXD] >>> 'Initialize Simple PDMC': 2 passed, 0 failed
```

```
+-------------------------+---------------------+----------------------------------------------------+-----------------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name       | test suite                                         | test case                               | passed | failed | result | elapsed_time (sec) |
+-------------------------+---------------------+----------------------------------------------------+-----------------------------------------+--------+--------+--------+--------------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Connect to WiFi                         | 2      | 0      | OK     | 3.75               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Format LFS                              | 1      | 0      | OK     | 0.25               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Initialize QSPIF+LFS                    | 2      | 0      | OK     | 0.06               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Initialize Simple PDMC                  | 2      | 0      | OK     | 2.8                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Pelion Bootstrap & Reg.                 | 1      | 0      | OK     | 13.8               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Pelion Directory                        | 1      | 0      | OK     | 0.86               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Pelion Firmware Download                | 1      | 0      | OK     | 90.09              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Pelion Firmware Prepare                 | 1      | 0      | OK     | 0.59               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Pelion Firmware Update                  | 1      | 0      | OK     | 15.27              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Pelion Re-register                      | 1      | 0      | OK     | 5.7                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Post-update Erase                       | 1      | 0      | OK     | 0.0                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | simple-mbed-cloud-client-tests-dev_mgmt-update     | Post-update Identity                    | 1      | 0      | OK     | 0.11               |
+-------------------------+---------------------+----------------------------------------------------+-----------------------------------------+--------+--------+--------+--------------------+
```
