### PR TITLE
Enlarge timeout for pelion bootstrap & register to 120s

### DIFF
--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -219,7 +219,7 @@ void spdmc_testsuite_connect(void) {
     client.on_registered(&registered);
     client.register_and_connect();
 
-    i = 600; // wait 60 seconds
+    i = 1200; // wait 120 seconds
     while (i-- > 0 && !client.is_client_registered()) {
         wait_ms(100);
     }

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -255,7 +255,7 @@ void spdmc_testsuite_update(void) {
     client.on_registered(&registered);
     client.register_and_connect();
 
-    i = 600; // wait 60 seconds
+    i = 1200; // wait 120 seconds
     while (i-- > 0 && !client.is_client_registered()) {
         wait_ms(100);
     }


### PR DESCRIPTION
On Nuvoton targets, I run PDMC tests and fail to pass the items: `smcc-tests-dev_mgmt-connect` / `Pelion Bootstrap & Reg` and `smcc-tests-dev_mgmt-update` / `Pelion Bootstrap & Reg`. The cause is too short timeout for bad network status. This PR enlarges the `pelion bootstrap & register` timeout to 120s to pass these tests.