### PR TITLE
add support for the "NO_LED" flag that disable the heartbeat thread

### DIFF
--- a/TESTS/basic/fs-single/main.cpp
+++ b/TESTS/basic/fs-single/main.cpp
@@ -137,8 +137,10 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
+#if defined(MBED_CONF_APP_NO_LED) && (MBED_CONF_APP_NO_LED == 1)
     Ticker t;
     t.attach(led_thread, 0.5);
+#endif
 
     return !Harness::run(specification);
 }

--- a/TESTS/basic/fs-threaded/main.cpp
+++ b/TESTS/basic/fs-threaded/main.cpp
@@ -146,8 +146,10 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
+#if defined(MBED_CONF_APP_NO_LED) && (MBED_CONF_APP_NO_LED == 1)
     Ticker t;
     t.attach(led_thread, 0.5);
+#endif
 
     return !Harness::run(specification);
 }

--- a/TESTS/basic/net-single/main.cpp
+++ b/TESTS/basic/net-single/main.cpp
@@ -117,8 +117,10 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
+#if defined(MBED_CONF_APP_NO_LED) && (MBED_CONF_APP_NO_LED == 1)
     Ticker t;
     t.attach(led_thread, 0.5);
+#endif
 
     return !Harness::run(specification);
 }

--- a/TESTS/basic/net-threaded/main.cpp
+++ b/TESTS/basic/net-threaded/main.cpp
@@ -154,8 +154,10 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
+#if defined(MBED_CONF_APP_NO_LED) && (MBED_CONF_APP_NO_LED == 1)
     Ticker t;
     t.attach(led_thread, 0.5);
+#endif
 
     return !Harness::run(specification);
 }

--- a/TESTS/basic/stress-net-fs/main.cpp
+++ b/TESTS/basic/stress-net-fs/main.cpp
@@ -191,8 +191,10 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
+#if defined(MBED_CONF_APP_NO_LED) && (MBED_CONF_APP_NO_LED == 1)
     Ticker t;
     t.attach(led_thread, 0.5);
+#endif
 
     return !Harness::run(specification);
 }

--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -455,8 +455,10 @@ void spdmc_testsuite_connect(void) {
 
 int main(void) {
     //Create a thread to blink an LED and signal that the device is alive
+#if defined(MBED_CONF_APP_NO_LED) && (MBED_CONF_APP_NO_LED == 1)
     Ticker t;
     t.attach(led_thread, 0.5);
+#endif
 
     greentea_send_kv("device_booted", 1);
 

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -387,8 +387,10 @@ void spdmc_testsuite_update(void) {
 
 int main(void) {
     //Create a thread to blink an LED and signal that the device is alive
+#if defined(MBED_CONF_APP_NO_LED) && (MBED_CONF_APP_NO_LED == 1)
     Ticker t;
     t.attach(led_thread, 0.5);
+#endif
 
     greentea_send_kv("device_booted", 1);
 


### PR DESCRIPTION
Some target such as the NUCLEO_L476RG has only 1 controllable led that conflict with SPI's CLK on Arduino's pin D13.

If set, this flag disables the led_thread.

Alternatively, this option could be provided as a proper config in mbed_lib.json.
Would that be a prefered solution to the solution in this PR ?