### PR TITLE
Avoid re-mounting filesystem on different BD

### DIFF
--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -178,7 +178,7 @@ void spdmc_testsuite_connect(void) {
     // SimpleMbedCloudClient initialization must be successful.
     test_case_start("Initialize Simple PDMC", 4);
 
-    SimpleMbedCloudClient client(net, bd, &fs);
+    SimpleMbedCloudClient client(net, &sd, &fs);
     int client_status = client.init();
 
     // Report status to console.

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -224,7 +224,7 @@ void spdmc_testsuite_update(void) {
     // SimpleMbedCloudClient initialization must be successful.
     test_case_start("Initialize Simple PDMC", 4);
 
-    SimpleMbedCloudClient client(net, bd, &fs);
+    SimpleMbedCloudClient client(net, &sd, &fs);
     int client_status = client.init();
 
     // Report status to console.

--- a/simple-mbed-cloud-client/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client/simple-mbed-cloud-client.cpp
@@ -43,8 +43,6 @@
 #define DEFAULT_FIRMWARE_PATH       "/fs/firmware"
 #endif
 
-BlockDevice *arm_uc_blockdevice;
-
 SimpleMbedCloudClient::SimpleMbedCloudClient(NetworkInterface *net, BlockDevice *bd, FileSystem *fs) :
     _registered(false),
     _register_called(false),
@@ -57,7 +55,6 @@ SimpleMbedCloudClient::SimpleMbedCloudClient(NetworkInterface *net, BlockDevice 
     _fs(fs),
     _storage(bd, fs)
 {
-    arm_uc_blockdevice = bd;
 }
 
 SimpleMbedCloudClient::~SimpleMbedCloudClient() {

--- a/simple-mbed-cloud-client/simple-mbed-cloud-client.h
+++ b/simple-mbed-cloud-client/simple-mbed-cloud-client.h
@@ -39,7 +39,7 @@ public:
      * Initialize SimpleMbedCloudClient
      *
      * @param net A connected network interface
-     * @param bd An uninitialized block device
+     * @param bd An uninitialized block device to back the file system
      * @param fs An uninitialized file system
      */
     SimpleMbedCloudClient(NetworkInterface *net, BlockDevice *bd, FileSystem *fs);

--- a/storage-helper/storage-helper.h
+++ b/storage-helper/storage-helper.h
@@ -98,7 +98,7 @@ public:
      * StorageHelper manages storage across multiple partitions,
      * initializes SOTP, and can format the storage.
      *
-     * @param bd An un-initialized block device
+     * @param bd An un-initialized block device to back the file system
      * @param fs An un-mounted file system
      */
     StorageHelper(BlockDevice *bd, FileSystem *fs);


### PR DESCRIPTION
Fix to avoid SimpleMbedCloudClient from re-initialising filesystem storage

As of MCC 2.1.0, arm_uc_blockdevice is no longer referenced from MCC, and is therefore pointless to keep in SMCC.
As such, SMCC only tracks the blockdevice backing the filesystem now, not the one backing both filesystem and upgrade storage. That solves the issue of the internal remount logic remounting the filesystem onto the full blockdevice, instead of the potentially smaller slicingblockdevice having been assigned to the filesystem earlier.