### PR TITLE
fixes the type of the value sent to the connect API.

### DIFF
--- a/TESTS/host_tests/sdk_host_tests.py
+++ b/TESTS/host_tests/sdk_host_tests.py
@@ -152,7 +152,7 @@ class SDKTests(BaseHostTest):
             self.send_safe("timeout", 0)
             return
 
-        updated_value = int(resource_value.value) + 5
+        updated_value = str(int(resource_value.value) + 5)
 
         # Set new resource value from cloud
         async_response = self.connectApi.set_resource_value_async(self.deviceID, value, updated_value)


### PR DESCRIPTION
Fixes this trace back :

```
[1550238799.45][HTST][INF] ==== Traceback start ====
Traceback (most recent call last):
  File "/.virt/local/lib/python2.7/site-packages/mbed_os_tools/test/host_tests_runner/host_test_default.py", line 422, in run_test
    callbacks[key](key, value, timestamp)
  File "/pelion-enablement/simple-mbed-cloud-client/TESTS/host_tests/sdk_host_tests.py", line 158, in _callback_verify_lwm2m_put
    async_response = self.connectApi.set_resource_value_async(self.deviceID, value, updated_value)
  File "/.virt/local/lib/python2.7/site-packages/mbed_cloud/decorators.py", line 33, in wrapped_f
    return fn(*args, **kwargs)
  File "/.virt/local/lib/python2.7/site-packages/mbed_cloud/connect/connect.py", line 356, in set_resource_value_async
    payload_b64 = base64.b64encode(resource_value.encode("utf-8")).decode("utf-8")
AttributeError: 'int' object has no attribute 'encode'
[1550238799.46][HTST][INF] ==== Traceback end ====
```