### PR TITLE
fix NO_LED defines, allowing devices with no LEDs to work

### DIFF
--- a/TESTS/basic/fs-single/main.cpp
+++ b/TESTS/basic/fs-single/main.cpp
@@ -42,12 +42,14 @@
 
 using namespace utest::v1;
 
+#if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 void led_thread() {
     led1 = !led1;
     led2 = !led1;
 }
+#endif
 
 BlockDevice* bd = BlockDevice::get_default_instance();
 SlicingBlockDevice sd(bd, 0, MBED_CONF_APP_BASICS_TEST_FS_SIZE);
@@ -137,7 +139,7 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
-#ifdef MBED_CONF_APP_NO_LED
+#if !defined(MBED_CONF_APP_NO_LED)
     Ticker t;
     t.attach(led_thread, 0.5);
 #endif

--- a/TESTS/basic/fs-threaded/main.cpp
+++ b/TESTS/basic/fs-threaded/main.cpp
@@ -42,12 +42,14 @@
 
 using namespace utest::v1;
 
+#if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 void led_thread() {
     led1 = !led1;
     led2 = !led1;
 }
+#endif
 
 BlockDevice* bd = BlockDevice::get_default_instance();
 SlicingBlockDevice sd(bd, 0, MBED_CONF_APP_BASICS_TEST_FS_SIZE);
@@ -146,7 +148,7 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
-#ifdef MBED_CONF_APP_NO_LED
+#if !defined(MBED_CONF_APP_NO_LED)
     Ticker t;
     t.attach(led_thread, 0.5);
 #endif

--- a/TESTS/basic/net-single/main.cpp
+++ b/TESTS/basic/net-single/main.cpp
@@ -41,12 +41,14 @@
 
 using namespace utest::v1;
 
+#if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 void led_thread() {
     led1 = !led1;
     led2 = !led1;
 }
+#endif
 
 #define MAX_RETRIES 3
 NetworkInterface* interface = NULL;
@@ -117,7 +119,7 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
-#ifdef MBED_CONF_APP_NO_LED
+#if !defined(MBED_CONF_APP_NO_LED)
     Ticker t;
     t.attach(led_thread, 0.5);
 #endif

--- a/TESTS/basic/net-threaded/main.cpp
+++ b/TESTS/basic/net-threaded/main.cpp
@@ -41,12 +41,14 @@
 
 using namespace utest::v1;
 
+#if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 void led_thread() {
     led1 = !led1;
     led2 = !led1;
 }
+#endif
 
 #define MAX_RETRIES 3
 NetworkInterface* net = NULL;
@@ -154,7 +156,7 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
-#ifdef MBED_CONF_APP_NO_LED
+#if !defined(MBED_CONF_APP_NO_LED)
     Ticker t;
     t.attach(led_thread, 0.5);
 #endif

--- a/TESTS/basic/stress-net-fs/main.cpp
+++ b/TESTS/basic/stress-net-fs/main.cpp
@@ -44,12 +44,15 @@
 
 using namespace utest::v1;
 
+#if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 void led_thread() {
     led1 = !led1;
     led2 = !led1;
 }
+#endif
+
 #define MAX_RETRIES 3
 NetworkInterface* interface = NULL;
 
@@ -206,7 +209,7 @@ Specification specification(greentea_setup, cases);
 
 int main() {
     //Create a thread to blink an LED and signal that the device is alive
-#ifdef MBED_CONF_APP_NO_LED
+#if !defined(MBED_CONF_APP_NO_LED)
     Ticker t;
     t.attach(led_thread, 0.5);
 #endif

--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -28,12 +28,15 @@
   #define MBED_CONF_APP_BASICS_TEST_FS_SIZE (2*1024*1024)
 #endif
 
+#if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 void led_thread() {
     led1 = !led1;
     led2 = !led1;
 }
+#endif
+
 RawSerial pc(USBTX, USBRX);
 
 void wait_nb(uint16_t ms) {
@@ -455,7 +458,7 @@ void spdmc_testsuite_connect(void) {
 
 int main(void) {
     //Create a thread to blink an LED and signal that the device is alive
-#ifdef MBED_CONF_APP_NO_LED
+#if !defined(MBED_CONF_APP_NO_LED)
     Ticker t;
     t.attach(led_thread, 0.5);
 #endif

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -30,12 +30,14 @@
 
 uint32_t test_timeout = 30*60;
 
+#if !defined(MBED_CONF_APP_NO_LED)
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 void led_thread() {
     led1 = !led1;
     led2 = !led1;
 }
+#endif
 RawSerial pc(USBTX, USBRX);
 
 void wait_nb(uint16_t ms) {
@@ -387,7 +389,7 @@ void spdmc_testsuite_update(void) {
 
 int main(void) {
     //Create a thread to blink an LED and signal that the device is alive
-#ifdef MBED_CONF_APP_NO_LED
+#if !defined(MBED_CONF_APP_NO_LED)
     Ticker t;
     t.attach(led_thread, 0.5);
 #endif


### PR DESCRIPTION
Putting LED1 and LED2 component when MBED_CONF_APP_NO_LED macro is not defined.

In original code, when MBED_CONF_APP_NO_LED is not defined, LED is not blinking; when MBED_CONF_APP_NO_LED is defined, LED is blinking, which is weird.