### PR TITLE
Disable C++ STL

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -103,6 +103,11 @@
         "secondary_partition_size": {
             "help": "Optional macro SECONDARY_PARTITION_SIZE in bytes, deault is 1GB. This requires auto_partition to be enabled.",
             "macro_name": "SECONDARY_PARTITION_SIZE"
+        },
+        "use-stl": {
+            "help": "Whether to use the C++ STL functions. If you're resource constrained and are not using STL string / vector in your application, disable it.",
+            "macro_name": "MBED_CLOUD_CLIENT_STL_API",
+            "value": 0
         }
     }
 }

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -105,7 +105,7 @@
             "macro_name": "SECONDARY_PARTITION_SIZE"
         },
         "enable-cpp-stl": {
-            "help": "Whether to use the C++ Standard Template Library (STL) functions with MbedCloudClient and LWM2M resources. If you're planning to make use of STL strings/vectors in your application, enable this. Note that your application will use about 10KB Flash.",
+            "help": "Enable this if you're already using STL strings/vectors in your application. If you don't use STL functionality, keep this disabled, as it will increase flash usage by 15K Flash.",
             "macro_name": "MBED_CLOUD_CLIENT_STL_API",
             "value": 0
         }

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -104,8 +104,8 @@
             "help": "Optional macro SECONDARY_PARTITION_SIZE in bytes, deault is 1GB. This requires auto_partition to be enabled.",
             "macro_name": "SECONDARY_PARTITION_SIZE"
         },
-        "use-stl": {
-            "help": "Whether to use the C++ STL functions. If you're resource constrained and are not using STL string / vector in your application, disable it.",
+        "enable-cpp-stl": {
+            "help": "Whether to use the C++ Standard Template Library (STL) functions with MbedCloudClient and LWM2M resources. If you're planning to make use of STL strings/vectors in your application, enable this. Note that your application will use about 10KB Flash.",
             "macro_name": "MBED_CLOUD_CLIENT_STL_API",
             "value": 0
         }


### PR DESCRIPTION
Based on the tip from https://github.com/ARMmbed/pelion-ready-example/pull/21. This saves 15K flash and 0.5K static RAM (and also some dynamic RAM, but that could have been a fluke).

Before:

```
Base (with memory tracing enabled)
===================================
Total Static RAM memory (data + bss): 78176 bytes
Total Flash memory (text + data): 426913 bytes

Heap size: 43701 / 117384 bytes (max: 50738 bytes)
```

After:

```
Disable STL
===========
Total Static RAM memory (data + bss): 77672 bytes
Total Flash memory (text + data): 411903 bytes

Heap size: 43257 / 117384 bytes (max: 50286 bytes)
```

Tested on K64F but would be good to verify in test farm.

@screamerbg 