### PR TITLE
Update to PDMC 3.0.0

### DIFF
--- a/mbed-cloud-client.lib
+++ b/mbed-cloud-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-cloud-client/#377c6b8fb0f8b66be03408a438ff0cd96be0c454
+https://github.com/ARMmbed/mbed-cloud-client/#4d7e04083520249109b042d8897b4b943825184e

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -2,7 +2,8 @@
     "name": "device-management",
     "macros": [
         "ARM_UC_USE_PAL_BLOCKDEVICE=1",
-        "MBED_CLOUD_CLIENT_UPDATE_STORAGE=ARM_UCP_FLASHIAP_BLOCKDEVICE"
+        "MBED_CLOUD_CLIENT_UPDATE_STORAGE=ARM_UCP_FLASHIAP_BLOCKDEVICE",
+        "MBED_CLIENT_DISABLE_EST_FEATURE"
     ],
     "config": {
         "flash-start-address": {


### PR DESCRIPTION
Note that this requires the application config to define `"mbed-cloud-client.external-sst-support"    : null` to re-enable the "legacy" nvstore SOTP support.