### PR TITLE
Enlarge Bootstrap & Reg timeout for NUMAKER_PFM_NUC472 platform

### DIFF
--- a/TESTS/dev_mgmt/connect/main.cpp
+++ b/TESTS/dev_mgmt/connect/main.cpp
@@ -222,7 +222,7 @@ void spdmc_testsuite_connect(void) {
     client.on_registered(&registered);
     client.register_and_connect();
 
-    i = 600; // wait 60 seconds
+    i = 650; // wait 65 seconds
     while (i-- > 0 && !client.is_client_registered()) {
         wait_ms(100);
     }

--- a/TESTS/dev_mgmt/update/main.cpp
+++ b/TESTS/dev_mgmt/update/main.cpp
@@ -267,7 +267,7 @@ void spdmc_testsuite_update(void) {
     client.on_registered(&registered);
     client.register_and_connect();
 
-    i = 600; // wait 60 seconds
+    i = 650; // wait 65 seconds
     while (i-- > 0 && !client.is_client_registered()) {
         wait_ms(100);
     }


### PR DESCRIPTION
The Bootstrap & Reg time is over 60 seconds on NUMAKER_PFM_NUC472 platform.
SMCC test log shows NUC472 Bootstrap & Reg time 62 seconds.
So enlarge time out from 60 seconds as 65 seconds.
[pfm_nuc472_dev_mgmt.log](https://github.com/ARMmbed/simple-mbed-cloud-client/files/3080138/pfm_nuc472_dev_mgmt.log)

Snippet of log as:
`[1555327983.63][CONN][RXD] >>> Running case #5: 'Pelion Bootstrap & Reg.'...
[1555327983.63][CONN][INF] found KV pair in stream: {{__testcase_start;Pelion Bootstrap & Reg.}}, queued...
[1555328045.13][CONN][RXD] [INFO] Connected to Pelion Device Management. Device ID: 016a20c6369000000000000100100371
[1555328045.32][CONN][RXD] [INFO] Device successfully registered to Pelion DM.`

Attached SMCC test log file for reference.