### PR TITLE
Fix SPDMC desctructor HardFault.

### DIFF
--- a/simple-mbed-cloud-client/simple-mbed-cloud-client.cpp
+++ b/simple-mbed-cloud-client/simple-mbed-cloud-client.cpp
@@ -58,7 +58,7 @@ SimpleMbedCloudClient::SimpleMbedCloudClient(NetworkInterface *net, BlockDevice 
 }
 
 SimpleMbedCloudClient::~SimpleMbedCloudClient() {
-    for (unsigned int i = 0; _resources.size(); i++) {
+    for (int i = 0; i < _resources.size(); i++) {
         delete _resources[i];
     }
 }


### PR DESCRIPTION
The hard fault was caused by an off-by-one error in the SPDMC destructor.
So for an example, when 3 resources were pushed to the list, 4 would be deleted.