### PR TITLE
Remove extra space from GET request

### DIFF
--- a/TESTS/COMMON/download_test.cpp
+++ b/TESTS/COMMON/download_test.cpp
@@ -41,7 +41,7 @@
   const char dl_path[] = "/mbed-test-files/alice.txt";
 #endif
 
-const char req_template[] = "GET %s  HTTP/1.1\nHost: %s\n\n";
+const char req_template[] = "GET %s HTTP/1.1\nHost: %s\n\n";
 
 #define REQ_BUF_SIZE        256
 #define RECV_BUF_SIZE       1024


### PR DESCRIPTION
I have observed that in download test, sometimes server returns HTTP Bad Request due to double spaces in GET request format. I tried multiple times with single space and did not get any error. It is suggested to remove the extra space as normally there's only one space in GET request format.

@MarceloSalazar 