### PR TITLE
add support for kvstore

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,9 +1,8 @@
 {
     "name": "device-management",
     "macros": [
-        "ARM_UC_USE_PAL_BLOCKDEVICE=1",
-        "MBED_CLOUD_CLIENT_UPDATE_STORAGE=ARM_UCP_FLASHIAP_BLOCKDEVICE",
-        "MBED_CLIENT_DISABLE_EST_FEATURE"
+        "MBED_BOOTLOADER_SIZE=(32*1024)",
+        "ARM_UC_USE_PAL_BLOCKDEVICE=1"
     ],
     "config": {
         "flash-start-address": {
@@ -64,7 +63,7 @@
         "pal-user-defined-configuration": {
             "help": "Defines which PAL configuration the board should use.",
             "macro_name": "PAL_USER_DEFINED_CONFIGURATION",
-            "value": "\"sotp_fs_config_MbedOS.h\""
+            "value": "\"pal_config_MbedOS.h\""
         },
         "pal_fs_mount_point_primary": {
             "help": "pal_fs_mount_point_primary",
@@ -110,5 +109,12 @@
             "macro_name": "MBED_CLOUD_CLIENT_STL_API",
             "value": 0
         }
-    }
+    },
+    "target_overrides": {
+        "*": {
+            "pal_number_of_partition": 1,
+            "partition_mode": 1,
+            "auto_partition": 1
+        }
+     }    
 }

--- a/simple-mbed-cloud-client/pal_config_MbedOS.h
+++ b/simple-mbed-cloud-client/pal_config_MbedOS.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018-2019 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PAL_CONFIG_MBEDOS
+#define PAL_CONFIG_MBEDOS
+
+#define PAL_USE_HW_ROT 0
+#define PAL_USE_HW_RTC 0
+#define PAL_USE_HW_TRNG 1
+#define PAL_SIMULATOR_FLASH_OVER_FILE_SYSTEM 0
+#define PAL_USE_INTERNAL_FLASH 0
+#define PAL_USE_SECURE_TIME 1
+
+
+#include "mbedOS_SST.h"
+
+
+#endif //PAL_CONFIG_MBEDOS

--- a/simple-mbed-cloud-client/simple-mbed-cloud-client.h
+++ b/simple-mbed-cloud-client/simple-mbed-cloud-client.h
@@ -45,6 +45,13 @@ public:
     SimpleMbedCloudClient(NetworkInterface *net, BlockDevice *bd, FileSystem *fs);
 
     /**
+     * Initialize SimpleMbedCloudClient without specifying storage
+     *
+     * @param net A connected network interface
+     */
+    SimpleMbedCloudClient(NetworkInterface *net);
+
+    /**
      * SimpleMbedCloudClient destructor
      *
      * This deletes all managed resources


### PR DESCRIPTION
This pull request adds support for kvstore to simple cloud client.  I've tested this on K64F and it is able to connect and register to Pelion.  

I've updated the connect and tests.  If mbed trace is disabled they all pass.  With mbed trace on, some tests seems to get lost in too much serial data and they report as skipped. 

Next steps:
- Get the connect test working - done
- Get the update test working - done
- Test with more boards
- Clean up the test case names, etc to fit kvstore instead of traditional file system.
- Maybe switch all boards to use kvstore and remove all SOTP storage related code.   